### PR TITLE
Fixed panic in SubscribeOnTransactions method

### DIFF
--- a/ton/transactions.go
+++ b/ton/transactions.go
@@ -250,18 +250,18 @@ func (c *APIClient) SubscribeOnTransactions(workerCtx context.Context, addr *add
 			transactions = append(transactions, res...)
 			waitList = 0 * time.Second
 		}
-		lastProcessedLT = transactions[0].LT // mark last transaction as known to not trigger twice
-
-		// reverse slice to send in correct time order (from old to new)
-		for i, j := 0, len(transactions)-1; i < j; i, j = i+1, j-1 {
-			transactions[i], transactions[j] = transactions[j], transactions[i]
-		}
-
-		for _, tx := range transactions {
-			channel <- tx
-		}
-
 		if len(transactions) > 0 {
+			lastProcessedLT = transactions[0].LT // mark last transaction as known to not trigger twice
+
+			// reverse slice to send in correct time order (from old to new)
+			for i, j := 0, len(transactions)-1; i < j; i, j = i+1, j-1 {
+				transactions[i], transactions[j] = transactions[j], transactions[i]
+			}
+
+			for _, tx := range transactions {
+				channel <- tx
+			}
+
 			wait = 0 * time.Second
 		}
 	}


### PR DESCRIPTION
In some cases first transaction in the result is fulfils this condition
https://github.com/xssnick/tonutils-go/blob/a7f4ad3fdb53556b4d9084216e408c05ffaf0bed/ton/transactions.go#L243
Therefore transactions variable contains empty slice which leads to panic in this line
https://github.com/xssnick/tonutils-go/blob/a7f4ad3fdb53556b4d9084216e408c05ffaf0bed/ton/transactions.go#L253