### PR TITLE
Heavy vector octet optimizations

### DIFF
--- a/adnl/rldp/raptorq/discmath/gf256.go
+++ b/adnl/rldp/raptorq/discmath/gf256.go
@@ -10,21 +10,15 @@ type GF256 struct {
 }
 
 func (g *GF256) Add(g2 *GF256) {
-	for i := 0; i < len(g.data); i++ {
-		g.data[i] ^= g2.data[i]
-	}
+	OctVecAdd(g.data, g2.data)
 }
 
 func (g *GF256) Mul(x uint8) {
-	for i := 0; i < len(g.data); i++ {
-		g.data[i] = OctMul(g.data[i], x)
-	}
+	OctVecMul(g.data, x)
 }
 
 func (g *GF256) AddMul(g2 *GF256, x uint8) {
-	for i := 0; i < len(g.data); i++ {
-		g.data[i] ^= OctAddMul(x, g2.data[i])
-	}
+	OctVecMulAdd(g.data, g2.data, x)
 }
 
 func (g *GF256) Bytes() []byte {


### PR DESCRIPTION
Old version:
```
Benchmark_EncodeDecodeFuzz-10         1790     611783 ns/op   652920 B/op     1810 allocs/op
Benchmark_EncodeDecodeFuzz-10         1803     600854 ns/op   652919 B/op     1810 allocs/op
Benchmark_EncodeDecodeFuzz-10         1818     619967 ns/op   652914 B/op     1809 allocs/op
```

New version:
```
Benchmark_EncodeDecodeFuzz-10         4076     252432 ns/op   652919 B/op     1810 allocs/op
Benchmark_EncodeDecodeFuzz-10         4021     272682 ns/op   652918 B/op     1810 allocs/op
Benchmark_EncodeDecodeFuzz-10         4015     252178 ns/op   652919 B/op     1810 allocs/op
```

**Result: ~ +125% perfomance increase**


