### PR TITLE
Improve wallet cold signing support

### DIFF
--- a/example/wallet-cold-alike/main.go
+++ b/example/wallet-cold-alike/main.go
@@ -2,13 +2,16 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
+	"log"
+	"strings"
+
 	"github.com/xssnick/tonutils-go/address"
 	"github.com/xssnick/tonutils-go/liteclient"
 	"github.com/xssnick/tonutils-go/tlb"
 	"github.com/xssnick/tonutils-go/ton"
 	"github.com/xssnick/tonutils-go/ton/wallet"
-	"log"
-	"strings"
+	"github.com/xssnick/tonutils-go/tvm/cell"
 )
 
 func main() {
@@ -42,6 +45,29 @@ func main() {
 		return
 	}
 
+	// get seqNo of the wallet, this is needed in the cold environment
+	var accountSeqNo uint32
+	resp, err := api.WaitForBlock(block.SeqNo).RunGetMethod(ctx, block, w.WalletAddress(), "seqno")
+	if err != nil {
+		log.Fatalln("get seqno err: %w", err)
+		return
+	}
+
+	iSeq, err := resp.Int(0)
+	if err != nil {
+		log.Fatalln("failed to parse seqno: %w", err)
+		return
+	}
+	accountSeqNo = uint32(iSeq.Uint64())
+
+	// determine if the wallet has been initialized, this is needed in the cold environment
+	acc, err := api.WaitForBlock(block.SeqNo).GetAccount(ctx, block, w.WalletAddress())
+	if err != nil {
+		log.Fatalln("failed to get account state: %w", err)
+	}
+
+	initialized := acc.IsActive && acc.State.Status == tlb.AccountStatusActive
+
 	balance, err := w.GetBalance(ctx, block)
 	if err != nil {
 		log.Fatalln("GetBalance err:", err.Error())
@@ -52,6 +78,10 @@ func main() {
 		addr := address.MustParseAddr("EQCD39VS5jcptHL8vMjEXrzGaRcCVYto7HUn4bpAOg8xqB2N")
 
 		log.Println("sending transaction...")
+
+		//////////////////////////////////////////////////////
+		// 1. build internal message in hot/online environment
+		//////////////////////////////////////////////////////
 
 		// default message ttl is 3 minutes, it is time during which you can send it to blockchain
 		// if you need to set longer TTL, you could use this method
@@ -64,19 +94,90 @@ func main() {
 			return
 		}
 
+		/////////////////////////////////////////////////////////////////////////////////////
+		// 2. serialize internal message to BoC before transiting to cold/offline environment
+		//    note: you'll need to also pass accountSeqNo and the initilized bool to the cold
+		//          environment because there won't be internet access.
+		/////////////////////////////////////////////////////////////////////////////////////
+
+		msgCell, err := tlb.ToCell(msg)
+		if err != nil {
+			log.Fatalln("ToCell err:", err.Error())
+			return
+		}
+
+		msgCellB64 := base64.StdEncoding.EncodeToString(msgCell.ToBOC())
+		log.Printf("internal message: %s, ready to be transited to cold system", msgCellB64)
+
+		////////////////////////////////////////////////////////////////
+		// 3. sign in the cold/offline environment after deserialization
+		////////////////////////////////////////////////////////////////
+
+		coldMsgCellBOC, err := base64.StdEncoding.DecodeString(msgCellB64)
+		if err != nil {
+			log.Fatalln("DecodeString err:", err.Error())
+			return
+		}
+
+		coldMsgCell, err := cell.FromBOC(coldMsgCellBOC)
+		if err != nil {
+			log.Fatalln("FromBOC err:", err.Error())
+			return
+		}
+
+		var coldMsg wallet.Message
+		err = tlb.LoadFromCell(&coldMsg, coldMsgCell.BeginParse())
+		if err != nil {
+			log.Fatalln("LoadFromCell err:", err.Error())
+			return
+		}
+
 		// pack message to send later or from other place
-		ext, err := w.BuildExternalMessage(ctx, msg)
+		ext, err := w.BuildExternalMessageOffline(ctx, accountSeqNo, initialized, &coldMsg)
 		if err != nil {
 			log.Fatalln("BuildExternalMessage err:", err.Error())
 			return
 		}
 
-		// if you wish to send it from diff source, or later, you could serialize it to BoC
-		// msgCell, _ := ext.ToCell()
-		// log.Println(base64.StdEncoding.EncodeToString(msgCell.ToBOC()))
+		////////////////////////////////////////////////////////////////////////////////////
+		// 4. serialize and transit external message to hot/online environment for broadcast
+		////////////////////////////////////////////////////////////////////////////////////
+
+		extCell, err := tlb.ToCell(ext)
+		if err != nil {
+			log.Fatalln("ToCell err:", err.Error())
+			return
+		}
+
+		extCellB64 := base64.StdEncoding.EncodeToString(extCell.ToBOC())
+
+		log.Printf("signed external message: %s, ready to be transited to hot system", extCellB64)
+
+		///////////////////////////////////////////////////////////
+		// 5. deserialize external message and broadcast to network
+		///////////////////////////////////////////////////////////
+
+		hotMsgCellBOC, err := base64.StdEncoding.DecodeString(extCellB64)
+		if err != nil {
+			log.Fatalln("DecodeString err:", err.Error())
+			return
+		}
+
+		hotMsgCell, err := cell.FromBOC(hotMsgCellBOC)
+		if err != nil {
+			log.Fatalln("FromBOC err:", err.Error())
+			return
+		}
+
+		var hotMsg tlb.ExternalMessage
+		err = tlb.LoadFromCell(&hotMsg, hotMsgCell.BeginParse())
+		if err != nil {
+			log.Fatalln("LoadFromCell err:", err.Error())
+			return
+		}
 
 		// send message to blockchain
-		err = api.SendExternalMessage(ctx, ext)
+		err = api.SendExternalMessage(ctx, &hotMsg)
 		if err != nil {
 			log.Fatalln("Failed to send external message:", err.Error())
 			return


### PR DESCRIPTION
Unless I'm mistaken, the current cold signing example doesn't work because `BuildExternalMessage` (where the signing occurs) requires internet access to make API calls.

My proposal includes a few changes:
1. Introduce `BuildExternalMessageOffline`, an offline alternative to `BuildExternalMessage`.
2. `BuildExternalMessageOffline` gets a `spec` from `getOfflineSpec`, which receives the SeqNo from the caller rather than getting it from the API.
3. Add TLB tags to for the `Wallet.Message` type.
4. A more detailed cold signing example.

I left a few todos since I'm not familiar enough with the codebase to remove or update cases for `HighloadV2R2` and `HighloadV2Verified`. If there's a better way to accomplish what I'm trying to do here without changes to the code, please let me know.

Finally, thanks for all your work on this project! It's a fantastic contribution to the TON ecosystem.

Tests:
Locally executed the cold signing example on the TON mainnet workchain with a different private key.