### PR TITLE
docs: NFT example code fix (InvalidIfaceAssign)

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,14 +265,8 @@ fmt.Println("    owner        :", nftData.OwnerAddress.String())
 fmt.Println("    index        :", nftData.Index)
 
 if nftData.Initialized {
-    // convert content to cell, we need it to get full url
-    nftContentCell, err := nftData.Content.ContentCell()
-    if err != nil {
-        panic(err)
-    }
-
     // get full nft's content url using collection method that will merge base url with nft's data
-    nftContent, err := collection.GetNFTContent(context.Background(), nftData.Index, nftContentCell)
+    nftContent, err := collection.GetNFTContent(context.Background(), nftData.Index, nftData.Content)
     if err != nil {
         panic(err)
     }


### PR DESCRIPTION
Fixing minor inaccuracy in the sample NFT code snippet:

> cannot use nftContentCell (variable of type *cell.Cell) as nft.ContentAny value in argument to collection.GetNFTContent: *cell.Cell does not implement nft.ContentAny (missing method ContentCell) compiler [InvalidIfaceAssign](https://pkg.go.dev/golang.org/x/tools/internal/typesinternal#InvalidIfaceAssign)

