### PR TITLE
FindTransaction & Offline LC & Dict Proof of no key & RLDP tunning

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <img align="right" width="425px" src="https://github.com/xssnick/props/blob/master/logoimg.png?raw=true">
 
 [![Based on TON][ton-svg]][ton]
-![Coverage](https://img.shields.io/badge/Coverage-74.0%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-73.8%25-brightgreen)
 
 Golang library for interacting with TON blockchain.
 

--- a/adnl/rldp/client_test.go
+++ b/adnl/rldp/client_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/ed25519"
 	"crypto/rand"
-	"encoding/hex"
 	"errors"
 	"github.com/xssnick/tonutils-go/adnl"
 	"github.com/xssnick/tonutils-go/adnl/rldp/raptorq"
@@ -227,7 +226,7 @@ func TestRLDP_handleMessage(t *testing.T) {
 					return nil
 				}
 			} else if test.tstSubName == "answer case" {
-				queryId := hex.EncodeToString(tQuery.ID)
+				queryId := string(tQuery.ID)
 				tChan := make(chan any, 2)
 				cli.activeRequests[queryId] = tChan
 			}
@@ -279,7 +278,7 @@ func TestRLDP_handleMessage(t *testing.T) {
 			if err != nil {
 				t.Fatal("failed to execute handleMessage func, err: ", err)
 			}
-			if cli.recvStreams[hex.EncodeToString(tId)].lastCompleteAt.IsZero() {
+			if cli.recvStreams[string(tId)].lastCompleteAt.IsZero() {
 				t.Error("got lastCompleteAt == nil, want != nil")
 			}
 		})
@@ -296,7 +295,7 @@ func TestRLDP_handleMessage(t *testing.T) {
 			cli := NewClient(tAdnl)
 
 			tChan := make(chan bool, 1)
-			cli.activeTransfers[hex.EncodeToString(tId)] = tChan
+			cli.activeTransfers[string(tId)] = tChan
 
 			err := cli.handleMessage(msgComplete)
 			if err != nil {

--- a/example/vanity_fast/main.go
+++ b/example/vanity_fast/main.go
@@ -97,7 +97,7 @@ func generateWallets(caseSensitive bool, suffix string, counter *uint64) {
 			binary.BigEndian.PutUint32(subwalletIDBytes, i)
 			getHashV3HashFromKey(hash, subwalletIDBytes, v3DataCell, v3StateInit, hashDst)
 
-			addr := address.NewAddress(0, 0, hashDst)
+			addr := address.NewAddress(0, 0, hashDst).Bounce(false)
 			addr.StringToBytes(addrTo, addrFrom)
 
 			if equalityFunc(suffix, string(addrTo[strCmpOffset:])) {

--- a/example/wallet-cold-alike/main.go
+++ b/example/wallet-cold-alike/main.go
@@ -13,6 +13,7 @@ import (
 )
 
 func main() {
+	// for completely offline mode you could use liteclient.NewOfflineClient() instead
 	client := liteclient.NewConnectionPool()
 
 	// connect to mainnet lite server

--- a/liteclient/integration_test.go
+++ b/liteclient/integration_test.go
@@ -69,6 +69,19 @@ func Test_Conn(t *testing.T) {
 	doReq(nil)
 }
 
+func Test_Offline(t *testing.T) {
+	client := NewOfflineClient()
+
+	doReq := func(expErr error) {
+		var resp tl.Serializable
+		err := client.QueryLiteserver(context.Background(), GetMasterchainInf{}, &resp)
+		if err != ErrOfflineMode {
+			t.Fatal("err", err)
+		}
+	}
+	doReq(nil)
+}
+
 func Test_ConnSticky(t *testing.T) {
 	client := NewConnectionPool()
 

--- a/liteclient/offline.go
+++ b/liteclient/offline.go
@@ -1,0 +1,31 @@
+package liteclient
+
+import (
+	"context"
+	"fmt"
+	"github.com/xssnick/tonutils-go/tl"
+)
+
+var ErrOfflineMode = fmt.Errorf("offline mode is used")
+
+type OfflineClient struct{}
+
+func NewOfflineClient() OfflineClient {
+	return OfflineClient{}
+}
+
+func (o OfflineClient) QueryLiteserver(ctx context.Context, payload tl.Serializable, result tl.Serializable) error {
+	return ErrOfflineMode
+}
+
+func (o OfflineClient) StickyContext(ctx context.Context) context.Context {
+	return nil
+}
+
+func (o OfflineClient) StickyContextNextNode(ctx context.Context) (context.Context, error) {
+	return ctx, nil
+}
+
+func (o OfflineClient) StickyNodeID(ctx context.Context) uint32 {
+	return 0
+}

--- a/ton/api.go
+++ b/ton/api.go
@@ -16,7 +16,6 @@ import (
 
 func init() {
 	tl.Register(LSError{}, "liteServer.error code:int message:string = liteServer.Error")
-
 }
 
 type ProofCheckPolicy int
@@ -74,6 +73,8 @@ type APIClientWrapped interface {
 	WithTimeout(timeout time.Duration) APIClientWrapped
 	SetTrustedBlock(block *BlockIDExt)
 	SetTrustedBlockFromConfig(cfg *liteclient.GlobalConfig)
+	FindLastTransactionByInMsgHash(ctx context.Context, addr *address.Address, msgHash []byte, maxTxNumToScan ...int) (*tlb.Transaction, error)
+	FindLastTransactionByOutMsgHash(ctx context.Context, addr *address.Address, msgHash []byte, maxTxNumToScan ...int) (*tlb.Transaction, error)
 }
 
 type APIClient struct {

--- a/ton/retrier.go
+++ b/ton/retrier.go
@@ -35,6 +35,14 @@ func (w *retryClient) QueryLiteserver(ctx context.Context, payload tl.Serializab
 
 				continue
 			}
+			if errors.Is(err, context.DeadlineExceeded) {
+				err := ctx.Err()
+				if err != nil {
+					return err
+				}
+				
+				continue
+			}
 
 			return err
 		}

--- a/ton/wallet/wallet_test.go
+++ b/ton/wallet/wallet_test.go
@@ -29,6 +29,16 @@ type MockAPI struct {
 	extMsgSent *tlb.ExternalMessage
 }
 
+func (m MockAPI) FindLastTransactionByInMsgHash(ctx context.Context, addr *address.Address, msgHash []byte, maxTxNumToScan ...int) (*tlb.Transaction, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
+func (m MockAPI) FindLastTransactionByOutMsgHash(ctx context.Context, addr *address.Address, msgHash []byte, maxTxNumToScan ...int) (*tlb.Transaction, error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 func (m MockAPI) WaitForBlock(seqno uint32) ton.APIClientWrapped {
 	return &WaiterMock{
 		MGetMasterchainInfo:  m.getBlockInfo,
@@ -452,23 +462,33 @@ func checkHighloadV2R2(t *testing.T, p *cell.Slice, w *Wallet, intMsg *tlb.Inter
 }
 
 type WaiterMock struct {
-	MGetTime                func(ctx context.Context) (uint32, error)
-	MLookupBlock            func(ctx context.Context, workchain int32, shard int64, seqno uint32) (*ton.BlockIDExt, error)
-	MGetBlockData           func(ctx context.Context, block *ton.BlockIDExt) (*tlb.Block, error)
-	MGetBlockTransactionsV2 func(ctx context.Context, block *ton.BlockIDExt, count uint32, after ...*ton.TransactionID3) ([]ton.TransactionShortInfo, bool, error)
-	MGetBlockShardsInfo     func(ctx context.Context, master *ton.BlockIDExt) ([]*ton.BlockIDExt, error)
-	MGetBlockchainConfig    func(ctx context.Context, block *ton.BlockIDExt, onlyParams ...int32) (*ton.BlockchainConfig, error)
-	MGetMasterchainInfo     func(ctx context.Context) (*ton.BlockIDExt, error)
-	MGetAccount             func(ctx context.Context, block *ton.BlockIDExt, addr *address.Address) (*tlb.Account, error)
-	MSendExternalMessage    func(ctx context.Context, msg *tlb.ExternalMessage) error
-	MRunGetMethod           func(ctx context.Context, blockInfo *ton.BlockIDExt, addr *address.Address, method string, params ...interface{}) (*ton.ExecutionResult, error)
-	MListTransactions       func(ctx context.Context, addr *address.Address, num uint32, lt uint64, txHash []byte) ([]*tlb.Transaction, error)
-	MGetTransaction         func(ctx context.Context, block *ton.BlockIDExt, addr *address.Address, lt uint64) (*tlb.Transaction, error)
-	MWaitForBlock           func(seqno uint32) ton.APIClientWrapped
-	MWithRetry              func(x ...int) ton.APIClientWrapped
-	MWithTimeout            func(timeout time.Duration) ton.APIClientWrapped
-	MCurrentMasterchainInfo func(ctx context.Context) (_ *ton.BlockIDExt, err error)
-	MGetBlockProof          func(ctx context.Context, known, target *ton.BlockIDExt) (*ton.PartialBlockProof, error)
+	MGetTime                         func(ctx context.Context) (uint32, error)
+	MLookupBlock                     func(ctx context.Context, workchain int32, shard int64, seqno uint32) (*ton.BlockIDExt, error)
+	MGetBlockData                    func(ctx context.Context, block *ton.BlockIDExt) (*tlb.Block, error)
+	MGetBlockTransactionsV2          func(ctx context.Context, block *ton.BlockIDExt, count uint32, after ...*ton.TransactionID3) ([]ton.TransactionShortInfo, bool, error)
+	MGetBlockShardsInfo              func(ctx context.Context, master *ton.BlockIDExt) ([]*ton.BlockIDExt, error)
+	MGetBlockchainConfig             func(ctx context.Context, block *ton.BlockIDExt, onlyParams ...int32) (*ton.BlockchainConfig, error)
+	MGetMasterchainInfo              func(ctx context.Context) (*ton.BlockIDExt, error)
+	MGetAccount                      func(ctx context.Context, block *ton.BlockIDExt, addr *address.Address) (*tlb.Account, error)
+	MSendExternalMessage             func(ctx context.Context, msg *tlb.ExternalMessage) error
+	MRunGetMethod                    func(ctx context.Context, blockInfo *ton.BlockIDExt, addr *address.Address, method string, params ...interface{}) (*ton.ExecutionResult, error)
+	MListTransactions                func(ctx context.Context, addr *address.Address, num uint32, lt uint64, txHash []byte) ([]*tlb.Transaction, error)
+	MGetTransaction                  func(ctx context.Context, block *ton.BlockIDExt, addr *address.Address, lt uint64) (*tlb.Transaction, error)
+	MWaitForBlock                    func(seqno uint32) ton.APIClientWrapped
+	MWithRetry                       func(x ...int) ton.APIClientWrapped
+	MWithTimeout                     func(timeout time.Duration) ton.APIClientWrapped
+	MCurrentMasterchainInfo          func(ctx context.Context) (_ *ton.BlockIDExt, err error)
+	MGetBlockProof                   func(ctx context.Context, known, target *ton.BlockIDExt) (*ton.PartialBlockProof, error)
+	MFindLastTransactionByInMsgHash  func(ctx context.Context, addr *address.Address, msgHash []byte, maxTxNumToScan ...int) (*tlb.Transaction, error)
+	MFindLastTransactionByOutMsgHash func(ctx context.Context, addr *address.Address, msgHash []byte, maxTxNumToScan ...int) (*tlb.Transaction, error)
+}
+
+func (w WaiterMock) FindLastTransactionByInMsgHash(ctx context.Context, addr *address.Address, msgHash []byte, maxTxNumToScan ...int) (*tlb.Transaction, error) {
+	return w.MFindLastTransactionByInMsgHash(ctx, addr, msgHash, maxTxNumToScan...)
+}
+
+func (w WaiterMock) FindLastTransactionByOutMsgHash(ctx context.Context, addr *address.Address, msgHash []byte, maxTxNumToScan ...int) (*tlb.Transaction, error) {
+	return w.MFindLastTransactionByOutMsgHash(ctx, addr, msgHash, maxTxNumToScan...)
 }
 
 func (w WaiterMock) GetLibraries(ctx context.Context, list ...[]byte) ([]*cell.Cell, error) {

--- a/tvm/cell/cell.go
+++ b/tvm/cell/cell.go
@@ -34,6 +34,15 @@ type Cell struct {
 	refs []*Cell
 }
 
+type RawUnsafeCell struct {
+	IsSpecial bool
+	LevelMask LevelMask
+	BitsSz    uint
+	Data      []byte
+
+	Refs []*Cell
+}
+
 func (c *Cell) copy() *Cell {
 	return &Cell{
 		special:     c.special,
@@ -68,6 +77,28 @@ func (c *Cell) ToBuilder() *Builder {
 		data:   data,
 		refs:   c.refs,
 	}
+}
+
+func (c *Cell) ToRawUnsafe() RawUnsafeCell {
+	return RawUnsafeCell{
+		IsSpecial: c.special,
+		LevelMask: c.levelMask,
+		BitsSz:    c.bitsSz,
+		Data:      c.data,
+		Refs:      c.refs,
+	}
+}
+
+func FromRawUnsafe(u RawUnsafeCell) *Cell {
+	c := &Cell{
+		special:   u.IsSpecial,
+		levelMask: u.LevelMask,
+		bitsSz:    u.BitsSz,
+		data:      u.Data,
+		refs:      u.Refs,
+	}
+	c.calculateHashes()
+	return c
 }
 
 func (c *Cell) BitsSize() uint {

--- a/tvm/cell/dict.go
+++ b/tvm/cell/dict.go
@@ -264,7 +264,8 @@ func (d *Dictionary) LoadValue(key *Cell) (*Slice, error) {
 
 // LoadValueWithProof - searches key in the underline dict cell, constructs proof path and returns leaf
 //
-//	If key is not found ErrNoSuchKeyInDict will be returned
+//	If key is not found ErrNoSuchKeyInDict will be returned,
+//	and path with proof of non-existing key will be attached to skeleton (if passed)
 func (d *Dictionary) LoadValueWithProof(key *Cell, skeleton *ProofSkeleton) (*Slice, *ProofSkeleton, error) {
 	if key.BitsSize() != d.keySz {
 		return nil, nil, fmt.Errorf("incorrect key size")
@@ -392,6 +393,9 @@ func (d *Dictionary) findKey(branch *Cell, lookupKey *Cell, at *ProofSkeleton) (
 		}
 
 		if !bytes.Equal(loadedPfx, pfx) {
+			if sk != nil {
+				at.Merge(root)
+			}
 			return nil, nil, ErrNoSuchKeyInDict
 		}
 


### PR DESCRIPTION
* Proof generation of key absence in dictionary
* Added FindLastTransactionByInMsgHash + FindLastTransactionByOutMsgHash to ton package
* Added Preload methods to cell slice (can be used instead of copy + load now, more efficient)
* Added methods ToRawUnsafe/FromRawUnsafe for manual low level cell construction
* Fixed transaction Dump method panic (when no outs)
* Builtin Offline LiteClient impl for cold wallets
* RLDP Tunning