### PR TITLE
Account proof fix

### DIFF
--- a/ton/getstate.go
+++ b/ton/getstate.go
@@ -3,6 +3,7 @@ package ton
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"github.com/xssnick/tonutils-go/address"
 	"github.com/xssnick/tonutils-go/tl"
@@ -58,12 +59,6 @@ func (c *APIClient) GetAccount(ctx context.Context, block *BlockIDExt, addr *add
 			return nil, fmt.Errorf("response with incorrect master block")
 		}
 
-		if t.State == nil {
-			return &tlb.Account{
-				IsActive: false,
-			}, nil
-		}
-
 		if t.Proof == nil {
 			return nil, fmt.Errorf("no proof")
 		}
@@ -86,8 +81,16 @@ func (c *APIClient) GetAccount(ctx context.Context, block *BlockIDExt, addr *add
 		}
 
 		shardAcc, balanceInfo, err := CheckAccountStateProof(addr, block, t.Proof, t.ShardProof, shardHash, c.proofCheckPolicy == ProofCheckPolicyUnsafe)
+		if errors.Is(err, ErrNoAddrInProof) && t.State == nil {
+			return &tlb.Account{
+				IsActive: false,
+			}, nil
+		}
 		if err != nil {
 			return nil, fmt.Errorf("failed to check acc state proof: %w", err)
+		}
+		if t.State == nil {
+			return nil, fmt.Errorf("state must be presented")
 		}
 
 		if !bytes.Equal(shardAcc.Account.Hash(0), t.State.Hash()) {

--- a/ton/getstate.go
+++ b/ton/getstate.go
@@ -73,7 +73,7 @@ func (c *APIClient) GetAccount(ctx context.Context, block *BlockIDExt, addr *add
 		}
 
 		var shardHash []byte
-		if c.proofCheckPolicy != ProofCheckPolicyUnsafe && addr.Workchain() != address.MasterchainID {
+		if c.proofCheckPolicy != ProofCheckPolicyUnsafe && addr.Workchain() != address.MasterchainID && !block.Equals(t.Shard) {
 			if len(t.ShardProof) == 0 {
 				return nil, ErrNoProof
 			}

--- a/ton/proof.go
+++ b/ton/proof.go
@@ -22,7 +22,10 @@ func init() {
 	tl.Register(ValidatorSetHashable{}, "test0.validatorSet#901660ed")
 }
 
-var ErrNoProof = fmt.Errorf("liteserver has no proof for this account in a given block, request newer block or disable proof checks")
+var (
+	ErrNoProof       = fmt.Errorf("liteserver has no proof for this account in a given block, request newer block or disable proof checks")
+	ErrNoAddrInProof = errors.New("no addr info in proof hashmap")
+)
 
 func CheckShardMcStateExtraProof(master *BlockIDExt, shardProof []*cell.Cell) (*tlb.McStateExtra, error) {
 	shardState, err := CheckBlockShardStateProof(shardProof, master.RootHash)
@@ -145,7 +148,7 @@ func CheckAccountStateProof(addr *address.Address, block *BlockIDExt, stateProof
 	addrKey := cell.BeginCell().MustStoreSlice(addr.Data(), 256).EndCell()
 	val := shardState.Accounts.ShardAccounts.Get(addrKey)
 	if val == nil {
-		return nil, nil, errors.New("no addr info in proof hashmap")
+		return nil, nil, ErrNoAddrInProof
 	}
 
 	loadVal := val.BeginParse()


### PR DESCRIPTION
1. Skip shard_proof for the requested trusted shard block
2. Performing proof check for a non-existent account