### PR TITLE
Added optional signer for wallet

### DIFF
--- a/ton/wallet/highloadv2r2.go
+++ b/ton/wallet/highloadv2r2.go
@@ -62,7 +62,11 @@ func (s *SpecHighloadV2R2) BuildMessage(ctx context.Context, messages []*Message
 		MustStoreUInt(boundedID, 64).
 		MustStoreDict(dict)
 
-	sign := payload.EndCell().Sign(s.wallet.key)
+	sign, err := s.wallet.signer(ctx, payload.EndCell())
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign: %w", err)
+	}
+
 	msg := cell.BeginCell().MustStoreSlice(sign, 512).MustStoreBuilder(payload).EndCell()
 
 	return msg, nil

--- a/ton/wallet/highloadv3.go
+++ b/ton/wallet/highloadv3.go
@@ -83,8 +83,13 @@ func (s *SpecHighloadV3) BuildMessage(ctx context.Context, messages []*Message) 
 		MustStoreUInt(uint64(s.config.MessageTTL), 22).
 		EndCell()
 
+	sign, err := s.wallet.signer(ctx, payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign: %w", err)
+	}
+
 	return cell.BeginCell().
-		MustStoreSlice(payload.Sign(s.wallet.key), 512).
+		MustStoreSlice(sign, 512).
 		MustStoreRef(payload).EndCell(), nil
 }
 

--- a/ton/wallet/v3.go
+++ b/ton/wallet/v3.go
@@ -47,7 +47,11 @@ func (s *SpecV3) BuildMessage(ctx context.Context, _ bool, _ *ton.BlockIDExt, me
 		payload.MustStoreUInt(uint64(message.Mode), 8).MustStoreRef(intMsg)
 	}
 
-	sign := payload.EndCell().Sign(s.wallet.key)
+	sign, err := s.wallet.signer(ctx, payload.EndCell())
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign: %w", err)
+	}
+
 	msg := cell.BeginCell().MustStoreSlice(sign, 512).MustStoreBuilder(payload).EndCell()
 
 	return msg, nil

--- a/ton/wallet/v4r2.go
+++ b/ton/wallet/v4r2.go
@@ -48,7 +48,11 @@ func (s *SpecV4R2) BuildMessage(ctx context.Context, _ bool, _ *ton.BlockIDExt, 
 		payload.MustStoreUInt(uint64(message.Mode), 8).MustStoreRef(intMsg)
 	}
 
-	sign := payload.EndCell().Sign(s.wallet.key)
+	sign, err := s.wallet.signer(ctx, payload.EndCell())
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign: %w", err)
+	}
+
 	msg := cell.BeginCell().MustStoreSlice(sign, 512).MustStoreBuilder(payload).EndCell()
 
 	return msg, nil

--- a/ton/wallet/v5beta.go
+++ b/ton/wallet/v5beta.go
@@ -58,7 +58,11 @@ func (s *SpecV5R1Beta) BuildMessage(ctx context.Context, _ bool, _ *ton.BlockIDE
 		MustStoreUInt(uint64(seq), 32).
 		MustStoreBuilder(actions)
 
-	sign := payload.EndCell().Sign(s.wallet.key)
+	sign, err := s.wallet.signer(ctx, payload.EndCell())
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign: %w", err)
+	}
+
 	msg := cell.BeginCell().MustStoreBuilder(payload).MustStoreSlice(sign, 512).EndCell()
 
 	return msg, nil

--- a/ton/wallet/v5r1.go
+++ b/ton/wallet/v5r1.go
@@ -85,7 +85,11 @@ func (s *SpecV5R1Final) BuildMessage(ctx context.Context, _ bool, _ *ton.BlockID
 		MustStoreUInt(uint64(seq), 32).                                                                   // seq (block)
 		MustStoreBuilder(actions)                                                                         // Action list
 
-	sign := payload.EndCell().Sign(s.wallet.key)
+	sign, err := s.wallet.signer(ctx, payload.EndCell())
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign: %w", err)
+	}
+
 	msg := cell.BeginCell().MustStoreBuilder(payload).MustStoreSlice(sign, 512).EndCell()
 
 	return msg, nil

--- a/ton/wallet/wallet.go
+++ b/ton/wallet/wallet.go
@@ -143,11 +143,14 @@ type Message struct {
 	InternalMessage *tlb.InternalMessage
 }
 
+type Signer func(context.Context, *cell.Cell) ([]byte, error)
+
 type Wallet struct {
-	api  TonAPI
-	key  ed25519.PrivateKey
-	addr *address.Address
-	ver  VersionConfig
+	api    TonAPI
+	key    ed25519.PrivateKey
+	pubKey ed25519.PublicKey
+	addr   *address.Address
+	ver    VersionConfig
 
 	// Can be used to operate multiple wallets with the same key and version.
 	// use GetSubwallet if you need it.
@@ -155,9 +158,35 @@ type Wallet struct {
 
 	// Stores a pointer to implementation of the version related functionality
 	spec any
+
+	signer Signer
 }
 
+type walletOption func(*Wallet)
+
 func FromPrivateKey(api TonAPI, key ed25519.PrivateKey, version VersionConfig) (*Wallet, error) {
+	return newWallet(
+		api,
+		key.Public().(ed25519.PublicKey),
+		version,
+		withPrivateKey(key),
+		withSigner(func(ctx context.Context, c *cell.Cell) ([]byte, error) {
+			if c == nil {
+				return nil, fmt.Errorf("cannot sign: cell is nil")
+			}
+			return c.Sign(key), nil
+		}))
+}
+
+func FromSigner(api TonAPI, publicKey ed25519.PublicKey, version VersionConfig, signer Signer) (*Wallet, error) {
+	return newWallet(
+		api,
+		publicKey,
+		version,
+		withSigner(signer))
+}
+
+func newWallet(api TonAPI, publicKey ed25519.PublicKey, version VersionConfig, options ...walletOption) (*Wallet, error) {
 	var subwallet uint32 = DefaultSubwallet
 
 	// default subwallet depends on wallet type
@@ -167,17 +196,21 @@ func FromPrivateKey(api TonAPI, key ed25519.PrivateKey, version VersionConfig) (
 		subwallet = 0
 	}
 
-	addr, err := AddressFromPubKey(key.Public().(ed25519.PublicKey), version, subwallet)
+	addr, err := AddressFromPubKey(publicKey, version, subwallet)
 	if err != nil {
 		return nil, err
 	}
 
 	w := &Wallet{
 		api:       api,
-		key:       key,
 		addr:      addr,
 		ver:       version,
 		subwallet: subwallet,
+		pubKey:    publicKey,
+	}
+
+	for _, opt := range options {
+		opt(w)
 	}
 
 	w.spec, err = getSpec(w)
@@ -186,6 +219,18 @@ func FromPrivateKey(api TonAPI, key ed25519.PrivateKey, version VersionConfig) (
 	}
 
 	return w, nil
+}
+
+func withPrivateKey(privateKey ed25519.PrivateKey) walletOption {
+	return func(w *Wallet) {
+		w.key = privateKey
+	}
+}
+
+func withSigner(signer Signer) walletOption {
+	return func(w *Wallet) {
+		w.signer = signer
+	}
 }
 
 func getSpec(w *Wallet) (any, error) {
@@ -270,7 +315,7 @@ func (w *Wallet) PrivateKey() ed25519.PrivateKey {
 }
 
 func (w *Wallet) GetSubwallet(subwallet uint32) (*Wallet, error) {
-	addr, err := AddressFromPubKey(w.key.Public().(ed25519.PublicKey), w.ver, subwallet)
+	addr, err := AddressFromPubKey(w.pubKey, w.ver, subwallet)
 	if err != nil {
 		return nil, err
 	}
@@ -278,9 +323,11 @@ func (w *Wallet) GetSubwallet(subwallet uint32) (*Wallet, error) {
 	sub := &Wallet{
 		api:       w.api,
 		key:       w.key,
+		pubKey:    w.pubKey,
 		addr:      addr,
 		ver:       w.ver,
 		subwallet: subwallet,
+		signer:    w.signer,
 	}
 
 	sub.spec, err = getSpec(sub)
@@ -341,7 +388,7 @@ func (w *Wallet) BuildExternalMessageForMany(ctx context.Context, messages []*Me
 func (w *Wallet) PrepareExternalMessageForMany(ctx context.Context, withStateInit bool, messages []*Message) (_ *tlb.ExternalMessage, err error) {
 	var stateInit *tlb.StateInit
 	if withStateInit {
-		stateInit, err = GetStateInit(w.key.Public().(ed25519.PublicKey), w.ver, w.subwallet)
+		stateInit, err = GetStateInit(w.pubKey, w.ver, w.subwallet)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get state init: %w", err)
 		}


### PR DESCRIPTION
Hello, the task was to teach the library to sign transactions using an external provider, since the keys are not always in the open. This code was tested on regular TON transfers and transfers in jettons.