### PR TITLE
Update config.go

### DIFF
--- a/liteclient/config.go
+++ b/liteclient/config.go
@@ -18,7 +18,7 @@ func GetConfigFromUrl(ctx context.Context, url string) (*GlobalConfig, error) {
 	if err != nil {
 		return nil, err
 	}
-
+        req.Header.Set("Accept", "*/*")
 	req = req.WithContext(ctx)
 
 	httpClient := http.DefaultClient


### PR DESCRIPTION
Fix bug 
"get config: invalid character '<' looking for beginning of value"