### PR TITLE
TON proof updates

### DIFF
--- a/ton/wallet/proof_test.go
+++ b/ton/wallet/proof_test.go
@@ -31,7 +31,7 @@ func TestTonConnectVerifier_VerifyProof(t *testing.T) {
 
 	addr := address.MustParseRawAddr(data.Address)
 
-	err = vi.VerifyProof(context.Background(), addr, data.Proof, data.StateInit)
+	err = vi.VerifyProof(context.Background(), addr, data.Proof, "1747303885:", data.StateInit)
 	if err != nil {
 		t.Fatalf("failed to verify proof: %v", err)
 	}

--- a/ton/wallet/proof_test.go
+++ b/ton/wallet/proof_test.go
@@ -31,9 +31,68 @@ func TestTonConnectVerifier_VerifyProof(t *testing.T) {
 
 	addr := address.MustParseRawAddr(data.Address)
 
-	err = vi.VerifyProof(context.Background(), addr, data.Proof, "1747303885:", data.StateInit)
+	err = vi.VerifyProof(context.Background(), addr, data.Proof, data.StateInit)
 	if err != nil {
 		t.Fatalf("failed to verify proof: %v", err)
 	}
 
+}
+
+func TestTonConnectVerifier_CheckPayload(t *testing.T) {
+	secret := "test_secret"
+
+	// Test case: Valid payload
+	t.Run("ValidPayload", func(t *testing.T) {
+		ttl := 5 * time.Second
+		payload, err := GeneratePayload(secret, ttl)
+		if err != nil {
+			t.Fatalf("GeneratePayload failed: %v", err)
+		}
+
+		err = CheckPayload(payload, secret)
+		if err != nil {
+			t.Errorf("CheckPayload failed for valid payload: %v", err)
+		}
+	})
+
+	// Test case: Expired payload
+	t.Run("ExpiredPayload", func(t *testing.T) {
+		ttl := -5 * time.Second // Already expired
+		payload, err := GeneratePayload(secret, ttl)
+		if err != nil {
+			t.Fatalf("GeneratePayload failed: %v", err)
+		}
+
+		err = CheckPayload(payload, secret)
+		if err == nil || err.Error() != "payload expired" {
+			t.Errorf("Expected 'payload expired', got: %v", err)
+		}
+	})
+
+	// Test case: Tampered payload
+	t.Run("TamperedPayload", func(t *testing.T) {
+		ttl := 5 * time.Second
+		payload, err := GeneratePayload(secret, ttl)
+		if err != nil {
+			t.Fatalf("GeneratePayload failed: %v", err)
+		}
+
+		// Tamper with the payload
+		tamperedPayload := payload[:len(payload)-1] + "a"
+
+		err = CheckPayload(tamperedPayload, secret)
+		if err == nil || err.Error() != "invalid payload signature" {
+			t.Errorf("Expected 'invalid payload signature', got: %v", err)
+		}
+	})
+
+	// Test case: Invalid payload length
+	t.Run("InvalidPayloadLength", func(t *testing.T) {
+		invalidPayload := "abcd" // Too short to be valid
+
+		err := CheckPayload(invalidPayload, secret)
+		if err == nil || err.Error() != "invalid payload length" {
+			t.Errorf("Expected 'invalid payload length', got: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
## 1. Its very hard to know what exactly payload was sent

``` go
func (v *TonConnectVerifier) VerifyProof(ctx context.Context, addr *address.Address, proof TonConnectProof, expectedPayload string, stateInit []byte) error {
	// ...

	if proof.Payload != expectedPayload {
		return errors.New("invalid payload in proof")
	}

	// ..
}
```
`ton/wallet/proof.go`

In the current implementation, when verifying TON proof, you **need to remember the exact payload** your server sent to the user. In practice, this can be very difficult or impossible

A better approach to verify that the payload was sent by your server is to sign the payload. This way, you can easily verify its origin **without having to remember it exactly** (similar to JWT)

#### Proposed Solution
The solution involves introducing two functions: `GeneratePayload` and `CheckPayload`, and simplify ` VerifyProof` 
- GeneratePayload: Generates a payload containing a random value and an expiration timestamp, then signs it using a secret.
- CheckPayload: Verifies the signature of the payload and validates the expiration timestamp.

Additionally, we can provide a new function, `VerifyProofWithPayload`, which accepts a custom `payloadVerifier` function to handle the payload verification logic:
```go
func (v *TonConnectVerifier) VerifyProofWithPayload(ctx context.Context, addr *address.Address, proof TonConnectProof, stateInit []byte, payloadVerifier func(payload, secret string) error, secret string) error {
	if err := payloadVerifier(proof.Payload, secret); err != nil {
		return fmt.Errorf("payload check failed: %w", err)
	}

	return v.VerifyProof(ctx, addr, proof, stateInit)
}
```

Remove the payload check from VerifyProof, as it is unrelated to the core verification logic:
```go
func (v *TonConnectVerifier) VerifyProof(ctx context.Context, addr *address.Address, proof TonConnectProof, stateInit []byte) error {
	// ...
}
```

## 2. Optimize getting a public key

When verifying a signature, we need to retrieve the public key. There are two possible ways:
1. Parse from `stateInit` (already provided in the request)
2. Or fetch via API or other external request if the wallet is already initialized

Currently, the implementation prioritizes fetching the public key via an API request and falls back to parsing it from `stateInit` only if the API request fails. However, parsing the key from stateInit is much faster and more reliable since it avoids making an external request

It will be more optimized to make the vice versa approach: firstly, try to parse the key from `stateInit`, as it's faster, and generally, we have it. And only if it fails, try to get the public key from the request, as it is longer and less reliable:

```go
func (v *TonConnectVerifier) getPubKey(ctx context.Context, addr *address.Address, stateInit []byte) (ed25519.PublicKey, error) {
	// First, try to get public key "offline" from stateInit
	key, err := getPublicKeyFromStateInit(addr, stateInit)

	// Only if it's impossible to parse public key from stateInit, make a request to get it
	if err != nil {
		key, err = GetPublicKey(ctx, v.client, addr)
		if err != nil {
			return nil, fmt.Errorf("failed to get public key: %w", err)
		}
	}

	return key, nil
}
```

