### PR TITLE
Expose prepareChecksumData as Bytes

### DIFF
--- a/address/addr.go
+++ b/address/addr.go
@@ -230,7 +230,10 @@ func ParseAddr(addr string) (*Address, error) {
 	if err != nil {
 		return nil, err
 	}
+	return ParseBytes(data)
+}
 
+func ParseBytes(data []byte) (*Address, error) {
 	if len(data) != 36 {
 		return nil, errors.New("incorrect address data")
 	}
@@ -267,10 +270,10 @@ func ParseRawAddr(addr string) (*Address, error) {
 }
 
 func (a *Address) Checksum() uint16 {
-	return crc16.Checksum(a.prepareChecksumData(), crc16.MakeTable(crc16.CRC16_XMODEM))
+	return crc16.Checksum(a.Bytes(), crc16.MakeTable(crc16.CRC16_XMODEM))
 }
 
-func (a *Address) prepareChecksumData() []byte {
+func (a *Address) Bytes() []byte {
 	var data [34]byte
 	data[0] = a.FlagsToByte()
 	data[1] = byte(a.workchain)

--- a/address/addr_test.go
+++ b/address/addr_test.go
@@ -334,7 +334,7 @@ func TestAddress_Workchain(t *testing.T) {
 	}
 }
 
-func TestAddress_prepareChecksumData(t *testing.T) {
+func TestAddress_Bytes(t *testing.T) {
 	type fields struct {
 		flags     flags
 		workchain int32
@@ -357,8 +357,8 @@ func TestAddress_prepareChecksumData(t *testing.T) {
 				workchain: tt.fields.workchain,
 				data:      tt.fields.data,
 			}
-			if got := a.prepareChecksumData(); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("prepareChecksumData() = %v, want %v", got, tt.want)
+			if got := a.Bytes(); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Bytes() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
It's useful to expose a raw representation, and most other chain SDKs provide a way to get a byte slice.