### PR TITLE
Add unit test: quick import path into Tonkeeper

### DIFF
--- a/ton/wallet/seed_test.go
+++ b/ton/wallet/seed_test.go
@@ -1,6 +1,8 @@
 package wallet
 
 import (
+	"encoding/hex"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -45,6 +47,25 @@ func TestNewSeedWithPassword(t *testing.T) {
 	if err == nil {
 		t.Fatal("should be invalid 5", seedNoPass)
 	}
+}
+
+func TestBIP39Create(t *testing.T) {
+	seed := NewSeed()
+	wallet, err := FromSeed(nil, seed, ConfigV5R1Final{
+		NetworkGlobalID: TestnetGlobalID,
+		Workchain:       0,
+	}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := wallet.WalletAddress()
+	addr.SetTestnetOnly(true)
+
+	// only test
+	fmt.Println("ton wallet seed:", seed)
+	fmt.Println("ton wallet testnet Address:", addr.String())
+	fmt.Println("ton wallet privateKey:", hex.EncodeToString(wallet.PrivateKey()))
+	fmt.Println("ton wallet publicKey:", hex.EncodeToString(wallet.pubKey))
 }
 
 func TestBIP39Load(t *testing.T) {

--- a/ton/wallet/seed_test.go
+++ b/ton/wallet/seed_test.go
@@ -59,19 +59,11 @@ func TestBIP39Create(t *testing.T) {
 		t.Fatal(err)
 	}
 	addr := wallet.WalletAddress()
-<<<<<<< HEAD
 	addr.SetTestnetOnly(true)
 
 	// only test
 	fmt.Println("ton wallet seed:", seed)
 	fmt.Println("ton wallet testnet Address:", addr.String())
-=======
-
-	// only test
-	fmt.Println("ton wallet seed:", seed)
-	fmt.Println("ton wallet mainnet Address:", addr.Copy().Testnet(false))
-	fmt.Println("ton wallet testnet Address:", addr.Copy().Testnet(true))
->>>>>>> 2820b25d042e8ccaaf05a86ba95b9b5302fa44dd
 	fmt.Println("ton wallet privateKey:", hex.EncodeToString(wallet.PrivateKey()))
 	fmt.Println("ton wallet publicKey:", hex.EncodeToString(wallet.pubKey))
 }


### PR DESCRIPTION
TON wallets typically use the TON mnemonic standard rather than BIP39. For developers starting to integrate TON wallets, this difference can be confusing. This PR adds a small, self-contained unit test that demonstrates a quick import path into Tonkeeper, serving as a practical reference for onboarding.