### PR TITLE
add unit TestBIP39Create

### DIFF
--- a/ton/wallet/seed_test.go
+++ b/ton/wallet/seed_test.go
@@ -1,6 +1,8 @@
 package wallet
 
 import (
+	"encoding/hex"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -45,6 +47,25 @@ func TestNewSeedWithPassword(t *testing.T) {
 	if err == nil {
 		t.Fatal("should be invalid 5", seedNoPass)
 	}
+}
+
+func TestBIP39Create(t *testing.T) {
+	seed := NewSeed()
+	wallet, err := FromSeed(nil, seed, ConfigV5R1Final{
+		NetworkGlobalID: TestnetGlobalID,
+		Workchain:       0,
+	}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := wallet.WalletAddress()
+	addr.SetTestnetOnly(true)
+
+	// only test
+	fmt.Println("ton wallet seed:", seed)
+	fmt.Println("ton wallet testnet Address:", addr.String())
+	fmt.Println("ton wallet privateKey:", hex.EncodeToString(wallet.PrivateKey()))
+	fmt.Println("ton wallet publicKey:", hex.EncodeToString(wallet.pubKey))
 }
 
 func TestBIP39Load(t *testing.T) {


### PR DESCRIPTION
TON wallets typically use the TON mnemonic standard rather than BIP39. For developers starting to integrate TON wallets, this difference can be confusing. This PR adds a small, self-contained unit test that demonstrates a quick import path into Tonkeeper, serving as a practical reference for onboarding.