### PR TITLE
refactor: use maps.Copy for cleaner map handling

### DIFF
--- a/adnl/overlay/overlay-adnl.go
+++ b/adnl/overlay/overlay-adnl.go
@@ -12,6 +12,7 @@ import (
 	"github.com/xssnick/tonutils-go/adnl/keys"
 	"github.com/xssnick/tonutils-go/adnl/rldp"
 	"github.com/xssnick/tonutils-go/tl"
+	"maps"
 	"reflect"
 	"sync"
 	"time"
@@ -88,9 +89,7 @@ func (a *ADNLOverlayWrapper) SetAuthorizedKeys(keysWithMaxLen map[string]uint32)
 
 	// reset and copy
 	a.authorizedKeys = map[string]uint32{}
-	for k, v := range keysWithMaxLen {
-		a.authorizedKeys[k] = v
-	}
+	maps.Copy(a.authorizedKeys, keysWithMaxLen)
 }
 
 func (a *ADNLWrapper) UnregisterOverlay(id []byte) {


### PR DESCRIPTION
There is a [new function](https://pkg.go.dev/maps@go1.21.1#Copy) added in the go1.21 standard library, which can make the code more concise and easy to read.