### PR TITLE
Fix MOD remainder handling for negative divisors

### DIFF
--- a/tvm/op/math/mod.go
+++ b/tvm/op/math/mod.go
@@ -13,20 +13,22 @@ func init() {
 func MOD() *helpers.SimpleOP {
 	return &helpers.SimpleOP{
 		Action: func(state *vm.State) error {
-			i0, err := state.Stack.PopIntFinite()
+			y, err := state.Stack.PopIntFinite()
 			if err != nil {
 				return err
 			}
-			i1, err := state.Stack.PopIntFinite()
+			x, err := state.Stack.PopIntFinite()
 			if err != nil {
 				return err
 			}
 
-			if i1.Sign() == 0 {
+			if y.Sign() == 0 {
 				return vmerr.Error(vmerr.CodeIntOverflow, "division by zero")
 			}
 
-			return state.Stack.PushInt(i0.Mod(i0, i1))
+			_, r := helpers.DivFloor(x, y)
+
+			return state.Stack.PushInt(r)
 		},
 		Name:   "MOD",
 		Prefix: []byte{0xA9, 0x08},

--- a/tvm/op/math/mod_test.go
+++ b/tvm/op/math/mod_test.go
@@ -1,0 +1,70 @@
+package math
+
+import (
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func TestModOperation(t *testing.T) {
+	tests := []struct {
+		x, y int64
+		want int64
+	}{
+		{10, 3, 1},
+		{10, -3, -2},
+		{-10, 3, 2},
+		{-10, -3, -1},
+		{7, -2, -1},
+		{-7, 4, 1},
+		{0, -3, 0},
+	}
+
+	st := vm.NewStack()
+
+	for _, test := range tests {
+		name := fmt.Sprintf("case -> x: %d y: %d, arg -> r: %d", test.x, test.y, test.want)
+		t.Run(name, func(t *testing.T) {
+			st.PushInt(big.NewInt(test.x))
+			st.PushInt(big.NewInt(test.y))
+
+			op := MOD()
+			err := op.Interpret(&vm.State{Stack: st})
+			if err != nil {
+				t.Fatal("Failed MOD execution:", err.Error())
+			}
+
+			res, err := st.PopIntFinite()
+			if err != nil {
+				t.Fatal("Failed to pop remainder:", err.Error())
+			}
+
+			if res.Cmp(big.NewInt(test.want)) != 0 {
+				t.Errorf("Expected remainder %d, got %d", test.want, res)
+			}
+
+			if test.y < 0 {
+				if res.Sign() > 0 || res.Cmp(big.NewInt(test.y)) <= 0 {
+					t.Errorf("Expected remainder to satisfy 0 >= r > %d, got %d", test.y, res)
+				}
+			} else {
+				if res.Sign() < 0 || res.Cmp(big.NewInt(test.y)) >= 0 {
+					t.Errorf("Expected remainder to satisfy 0 <= r < %d, got %d", test.y, res)
+				}
+			}
+		})
+	}
+}
+
+func TestModOperationDivisionByZero(t *testing.T) {
+	st := vm.NewStack()
+	st.PushInt(big.NewInt(10))
+	st.PushInt(big.NewInt(0))
+
+	op := MOD()
+	if err := op.Interpret(&vm.State{Stack: st}); err == nil {
+		t.Fatal("expected division by zero error")
+	}
+}


### PR DESCRIPTION
## Summary
- adjust the MOD opcode to compute its remainder via floor division so negative divisors follow the C++ semantics
- add regression tests for MOD that cover negative divisors and division by zero behaviour

## Testing
- go test ./tvm/op/...


------
https://chatgpt.com/codex/tasks/task_e_68cfb9c32b708320a8fe9dab93e14c82