### PR TITLE
Implement missing TVM stack operations

### DIFF
--- a/tvm/op/stack/basic_ops_test.go
+++ b/tvm/op/stack/basic_ops_test.go
@@ -1,0 +1,63 @@
+package stack
+
+import (
+	"testing"
+
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func TestSWAP(t *testing.T) {
+	st := newStack(1, 2)
+	if err := SWAP().Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("SWAP failed: %v", err)
+	}
+	got := popInts(t, st, 2)
+	want := []int64{1, 2}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v at %d, got %v", want, i, got)
+		}
+	}
+}
+
+func TestDUP(t *testing.T) {
+	st := newStack(7)
+	if err := DUP().Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("DUP failed: %v", err)
+	}
+	got := popInts(t, st, 2)
+	want := []int64{7, 7}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestOVER(t *testing.T) {
+	st := newStack(1, 2)
+	if err := OVER().Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("OVER failed: %v", err)
+	}
+	got := popInts(t, st, 3)
+	want := []int64{1, 2, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestNIP(t *testing.T) {
+	st := newStack(1, 2, 3)
+	if err := NIP().Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("NIP failed: %v", err)
+	}
+	got := popInts(t, st, 2)
+	want := []int64{3, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}

--- a/tvm/op/stack/blkswx.go
+++ b/tvm/op/stack/blkswx.go
@@ -1,0 +1,41 @@
+package stack
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+	"github.com/xssnick/tonutils-go/tvm/vmerr"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return BLKSWX() })
+}
+
+func BLKSWX() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Action: func(state *vm.State) error {
+			y, err := popSmallIndex(state)
+			if err != nil {
+				return err
+			}
+			x, err := popSmallIndex(state)
+			if err != nil {
+				return err
+			}
+			if x < 0 || y < 0 || x+y > state.Stack.Len() {
+				return vmerr.Error(vmerr.CodeStackUnderflow)
+			}
+			if x == 0 || y == 0 {
+				return nil
+			}
+			if err := state.Stack.Reverse(x+y-1, y); err != nil {
+				return err
+			}
+			if err := state.Stack.Reverse(y-1, 0); err != nil {
+				return err
+			}
+			return state.Stack.Reverse(x+y-1, 0)
+		},
+		Name:   "BLKSWX",
+		Prefix: []byte{0x63},
+	}
+}

--- a/tvm/op/stack/chkdepth.go
+++ b/tvm/op/stack/chkdepth.go
@@ -1,0 +1,28 @@
+package stack
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+	"github.com/xssnick/tonutils-go/tvm/vmerr"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return CHKDEPTH() })
+}
+
+func CHKDEPTH() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Action: func(state *vm.State) error {
+			idx, err := popSmallIndex(state)
+			if err != nil {
+				return err
+			}
+			if idx > state.Stack.Len() {
+				return vmerr.Error(vmerr.CodeStackUnderflow)
+			}
+			return nil
+		},
+		Name:   "CHKDEPTH",
+		Prefix: []byte{0x69},
+	}
+}

--- a/tvm/op/stack/depth.go
+++ b/tvm/op/stack/depth.go
@@ -1,0 +1,22 @@
+package stack
+
+import (
+	"math/big"
+
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return DEPTH() })
+}
+
+func DEPTH() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Action: func(state *vm.State) error {
+			return state.Stack.PushInt(big.NewInt(int64(state.Stack.Len())))
+		},
+		Name:   "DEPTH",
+		Prefix: []byte{0x68},
+	}
+}

--- a/tvm/op/stack/dropx.go
+++ b/tvm/op/stack/dropx.go
@@ -1,0 +1,24 @@
+package stack
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return DROPX() })
+}
+
+func DROPX() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Action: func(state *vm.State) error {
+			idx, err := popSmallIndex(state)
+			if err != nil {
+				return err
+			}
+			return state.Stack.Drop(idx)
+		},
+		Name:   "DROPX",
+		Prefix: []byte{0x65},
+	}
+}

--- a/tvm/op/stack/dup.go
+++ b/tvm/op/stack/dup.go
@@ -1,0 +1,20 @@
+package stack
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return DUP() })
+}
+
+func DUP() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Action: func(state *vm.State) error {
+			return state.Stack.PushAt(0)
+		},
+		Name:   "DUP",
+		Prefix: []byte{0x20},
+	}
+}

--- a/tvm/op/stack/dup2.go
+++ b/tvm/op/stack/dup2.go
@@ -27,7 +27,7 @@ func DUP2() *helpers.SimpleOP {
 
 			return state.Stack.PushAny(b)
 		},
-		Name:   "DUP2",
+		Name:   "2DUP",
 		Prefix: []byte{0x5C},
 	}
 }

--- a/tvm/op/stack/dynamic_ops_test.go
+++ b/tvm/op/stack/dynamic_ops_test.go
@@ -1,0 +1,201 @@
+package stack
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func TestPICK(t *testing.T) {
+	st := newStack(1, 2, 3, 4)
+	if err := st.PushAny(big.NewInt(2)); err != nil {
+		t.Fatalf("failed to push index: %v", err)
+	}
+	if err := PICK().Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("PICK failed: %v", err)
+	}
+	got := popInts(t, st, 5)
+	want := []int64{2, 4, 3, 2, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestROLL(t *testing.T) {
+	st := newStack(1, 2, 3, 4)
+	if err := st.PushAny(big.NewInt(2)); err != nil {
+		t.Fatalf("failed to push index: %v", err)
+	}
+	if err := ROLL().Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("ROLL failed: %v", err)
+	}
+	got := popInts(t, st, 4)
+	want := []int64{2, 4, 3, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestROLLREV(t *testing.T) {
+	st := newStack(1, 2, 3, 4)
+	if err := st.PushAny(big.NewInt(2)); err != nil {
+		t.Fatalf("failed to push index: %v", err)
+	}
+	if err := ROLLREV().Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("ROLLREV failed: %v", err)
+	}
+	got := popInts(t, st, 4)
+	want := []int64{3, 2, 4, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestBLKSWX(t *testing.T) {
+	st := newStack(1, 2, 3)
+	if err := st.PushAny(big.NewInt(1)); err != nil {
+		t.Fatalf("failed to push x: %v", err)
+	}
+	if err := st.PushAny(big.NewInt(2)); err != nil {
+		t.Fatalf("failed to push y: %v", err)
+	}
+	if err := BLKSWX().Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("BLKSWX failed: %v", err)
+	}
+	got := popInts(t, st, 3)
+	want := []int64{1, 3, 2}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestREVX(t *testing.T) {
+	st := newStack(1, 2, 3, 4)
+	if err := st.PushAny(big.NewInt(2)); err != nil {
+		t.Fatalf("failed to push x: %v", err)
+	}
+	if err := st.PushAny(big.NewInt(1)); err != nil {
+		t.Fatalf("failed to push y: %v", err)
+	}
+	if err := REVX().Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("REVX failed: %v", err)
+	}
+	got := popInts(t, st, 4)
+	want := []int64{4, 2, 3, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestDROPX(t *testing.T) {
+	st := newStack(1, 2, 3, 4)
+	if err := st.PushAny(big.NewInt(2)); err != nil {
+		t.Fatalf("failed to push count: %v", err)
+	}
+	if err := DROPX().Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("DROPX failed: %v", err)
+	}
+	got := popInts(t, st, 2)
+	want := []int64{2, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestXCHGX(t *testing.T) {
+	st := newStack(1, 2, 3, 4)
+	if err := st.PushAny(big.NewInt(2)); err != nil {
+		t.Fatalf("failed to push index: %v", err)
+	}
+	if err := XCHGX().Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("XCHGX failed: %v", err)
+	}
+	got := popInts(t, st, 4)
+	want := []int64{2, 3, 4, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestDEPTH(t *testing.T) {
+	st := newStack(1, 2, 3)
+	if err := DEPTH().Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("DEPTH failed: %v", err)
+	}
+	got := popInts(t, st, 1)
+	if got[0] != 3 {
+		t.Fatalf("expected depth 3, got %v", got[0])
+	}
+	if st.Len() != 3 {
+		t.Fatalf("expected stack length 3, got %d", st.Len())
+	}
+}
+
+func TestCHKDEPTH(t *testing.T) {
+	st := newStack(1, 2, 3)
+	if err := st.PushAny(big.NewInt(3)); err != nil {
+		t.Fatalf("failed to push depth: %v", err)
+	}
+	if err := CHKDEPTH().Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("CHKDEPTH failed: %v", err)
+	}
+	if st.Len() != 3 {
+		t.Fatalf("expected stack length 3, got %d", st.Len())
+	}
+	got := popInts(t, st, 3)
+	want := []int64{3, 2, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestONLYTOPX(t *testing.T) {
+	st := newStack(1, 2, 3, 4)
+	if err := st.PushAny(big.NewInt(2)); err != nil {
+		t.Fatalf("failed to push count: %v", err)
+	}
+	if err := ONLYTOPX().Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("ONLYTOPX failed: %v", err)
+	}
+	got := popInts(t, st, 2)
+	want := []int64{4, 3}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestONLYX(t *testing.T) {
+	st := newStack(1, 2, 3, 4)
+	if err := st.PushAny(big.NewInt(2)); err != nil {
+		t.Fatalf("failed to push count: %v", err)
+	}
+	if err := ONLYX().Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("ONLYX failed: %v", err)
+	}
+	got := popInts(t, st, 2)
+	want := []int64{2, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}

--- a/tvm/op/stack/internal.go
+++ b/tvm/op/stack/internal.go
@@ -1,0 +1,16 @@
+package stack
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+const maxSmallIndex = (1 << 30) - 1
+
+func popSmallIndex(state *vm.State) (int, error) {
+	val, err := state.Stack.PopIntRange(0, maxSmallIndex)
+	if err != nil {
+		return 0, err
+	}
+
+	return int(val.Int64()), nil
+}

--- a/tvm/op/stack/long_ops_test.go
+++ b/tvm/op/stack/long_ops_test.go
@@ -1,0 +1,49 @@
+package stack
+
+import (
+	"testing"
+
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func TestXCHG0L(t *testing.T) {
+	st := newStack(1, 2, 3, 4, 5)
+	if err := XCHG0L(3).Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("XCHG0L failed: %v", err)
+	}
+	got := popInts(t, st, 5)
+	want := []int64{2, 4, 3, 5, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestPUSHL(t *testing.T) {
+	st := newStack(1, 2, 3, 4, 5)
+	if err := PUSHL(3).Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("PUSHL failed: %v", err)
+	}
+	got := popInts(t, st, 6)
+	want := []int64{2, 5, 4, 3, 2, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestPOPL(t *testing.T) {
+	st := newStack(1, 2, 3, 4, 5)
+	if err := POPL(3).Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("POPL failed: %v", err)
+	}
+	got := popInts(t, st, 4)
+	want := []int64{4, 3, 5, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}

--- a/tvm/op/stack/multi.go
+++ b/tvm/op/stack/multi.go
@@ -1,0 +1,383 @@
+package stack
+
+import (
+	"fmt"
+
+	"github.com/xssnick/tonutils-go/tvm/cell"
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return XC2PU(0, 0, 0) })
+	vm.List = append(vm.List, func() vm.OP { return XCPUXC(0, 0, 0) })
+	vm.List = append(vm.List, func() vm.OP { return XCPU2(0, 0, 0) })
+	vm.List = append(vm.List, func() vm.OP { return PUXC2(0, 0, 0) })
+	vm.List = append(vm.List, func() vm.OP { return PUXCPU(0, 0, 0) })
+	vm.List = append(vm.List, func() vm.OP { return PU2XC(0, 0, 0) })
+	vm.List = append(vm.List, func() vm.OP { return PUSH3(0, 0, 0) })
+}
+
+func XC2PU(i, j, k uint8) (op *helpers.AdvancedOP) {
+	op = &helpers.AdvancedOP{
+		Action: func(state *vm.State) error {
+			if err := state.Stack.Exchange(1, int(i)); err != nil {
+				return err
+			}
+			if err := state.Stack.Exchange(0, int(j)); err != nil {
+				return err
+			}
+			val, err := state.Stack.Get(int(k))
+			if err != nil {
+				return err
+			}
+			return state.Stack.PushAny(val)
+		},
+		NameSerializer: func() string {
+			return fmt.Sprintf("%d,%d,%d XC2PU", i, j, k)
+		},
+		Prefix: cell.BeginCell().MustStoreUInt(0x541, 12).EndCell(),
+		SerializeSuffix: func() *cell.Builder {
+			return cell.BeginCell().
+				MustStoreUInt(uint64(i), 4).
+				MustStoreUInt(uint64(j), 4).
+				MustStoreUInt(uint64(k), 4)
+		},
+		DeserializeSuffix: func(code *cell.Slice) error {
+			ival, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			jval, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			kval, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			i = uint8(ival)
+			j = uint8(jval)
+			k = uint8(kval)
+			return nil
+		},
+	}
+	return op
+}
+
+func XCPUXC(i, j, k uint8) (op *helpers.AdvancedOP) {
+	op = &helpers.AdvancedOP{
+		Action: func(state *vm.State) error {
+			if err := state.Stack.Exchange(1, int(i)); err != nil {
+				return err
+			}
+			val, err := state.Stack.Get(int(j))
+			if err != nil {
+				return err
+			}
+			if err := state.Stack.PushAny(val); err != nil {
+				return err
+			}
+			if err := state.Stack.Exchange(0, 1); err != nil {
+				return err
+			}
+			return state.Stack.Exchange(0, int(k))
+		},
+		NameSerializer: func() string {
+			return fmt.Sprintf("%d,%d,%d XCPUXC", i, j, k)
+		},
+		Prefix: cell.BeginCell().MustStoreUInt(0x542, 12).EndCell(),
+		SerializeSuffix: func() *cell.Builder {
+			return cell.BeginCell().
+				MustStoreUInt(uint64(i), 4).
+				MustStoreUInt(uint64(j), 4).
+				MustStoreUInt(uint64(k), 4)
+		},
+		DeserializeSuffix: func(code *cell.Slice) error {
+			ival, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			jval, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			kval, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			i = uint8(ival)
+			j = uint8(jval)
+			k = uint8(kval)
+			return nil
+		},
+	}
+	return op
+}
+
+func XCPU2(i, j, k uint8) (op *helpers.AdvancedOP) {
+	op = &helpers.AdvancedOP{
+		Action: func(state *vm.State) error {
+			if err := state.Stack.Exchange(0, int(i)); err != nil {
+				return err
+			}
+			val, err := state.Stack.Get(int(j))
+			if err != nil {
+				return err
+			}
+			if err := state.Stack.PushAny(val); err != nil {
+				return err
+			}
+			val, err = state.Stack.Get(int(k) + 1)
+			if err != nil {
+				return err
+			}
+			return state.Stack.PushAny(val)
+		},
+		NameSerializer: func() string {
+			return fmt.Sprintf("%d,%d,%d XCPU2", i, j, k)
+		},
+		Prefix: cell.BeginCell().MustStoreUInt(0x543, 12).EndCell(),
+		SerializeSuffix: func() *cell.Builder {
+			return cell.BeginCell().
+				MustStoreUInt(uint64(i), 4).
+				MustStoreUInt(uint64(j), 4).
+				MustStoreUInt(uint64(k), 4)
+		},
+		DeserializeSuffix: func(code *cell.Slice) error {
+			ival, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			jval, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			kval, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			i = uint8(ival)
+			j = uint8(jval)
+			k = uint8(kval)
+			return nil
+		},
+	}
+	return op
+}
+
+func PUXC2(i, j, k uint8) (op *helpers.AdvancedOP) {
+	op = &helpers.AdvancedOP{
+		Action: func(state *vm.State) error {
+			val, err := state.Stack.Get(int(i))
+			if err != nil {
+				return err
+			}
+			if err := state.Stack.PushAny(val); err != nil {
+				return err
+			}
+			if err := state.Stack.Exchange(2, 0); err != nil {
+				return err
+			}
+			if err := state.Stack.Exchange(1, int(j)); err != nil {
+				return err
+			}
+			return state.Stack.Exchange(0, int(k))
+		},
+		NameSerializer: func() string {
+			return fmt.Sprintf("%d,%d,%d PUXC2", i, j, k)
+		},
+		Prefix: cell.BeginCell().MustStoreUInt(0x544, 12).EndCell(),
+		SerializeSuffix: func() *cell.Builder {
+			return cell.BeginCell().
+				MustStoreUInt(uint64(i), 4).
+				MustStoreUInt(uint64(j), 4).
+				MustStoreUInt(uint64(k), 4)
+		},
+		DeserializeSuffix: func(code *cell.Slice) error {
+			ival, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			jval, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			kval, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			i = uint8(ival)
+			j = uint8(jval)
+			k = uint8(kval)
+			return nil
+		},
+	}
+	return op
+}
+
+func PUXCPU(i, j, k uint8) (op *helpers.AdvancedOP) {
+	op = &helpers.AdvancedOP{
+		Action: func(state *vm.State) error {
+			val, err := state.Stack.Get(int(i))
+			if err != nil {
+				return err
+			}
+			if err := state.Stack.PushAny(val); err != nil {
+				return err
+			}
+			if err := state.Stack.Exchange(0, 1); err != nil {
+				return err
+			}
+			if err := state.Stack.Exchange(0, int(j)); err != nil {
+				return err
+			}
+			val, err = state.Stack.Get(int(k))
+			if err != nil {
+				return err
+			}
+			return state.Stack.PushAny(val)
+		},
+		NameSerializer: func() string {
+			return fmt.Sprintf("%d,%d,%d PUXCPU", i, j, k)
+		},
+		Prefix: cell.BeginCell().MustStoreUInt(0x545, 12).EndCell(),
+		SerializeSuffix: func() *cell.Builder {
+			return cell.BeginCell().
+				MustStoreUInt(uint64(i), 4).
+				MustStoreUInt(uint64(j), 4).
+				MustStoreUInt(uint64(k), 4)
+		},
+		DeserializeSuffix: func(code *cell.Slice) error {
+			ival, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			jval, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			kval, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			i = uint8(ival)
+			j = uint8(jval)
+			k = uint8(kval)
+			return nil
+		},
+	}
+	return op
+}
+
+func PU2XC(i, j, k uint8) (op *helpers.AdvancedOP) {
+	op = &helpers.AdvancedOP{
+		Action: func(state *vm.State) error {
+			val, err := state.Stack.Get(int(i))
+			if err != nil {
+				return err
+			}
+			if err := state.Stack.PushAny(val); err != nil {
+				return err
+			}
+			if err := state.Stack.Exchange(1, 0); err != nil {
+				return err
+			}
+			val, err = state.Stack.Get(int(j))
+			if err != nil {
+				return err
+			}
+			if err := state.Stack.PushAny(val); err != nil {
+				return err
+			}
+			if err := state.Stack.Exchange(1, 0); err != nil {
+				return err
+			}
+			return state.Stack.Exchange(0, int(k))
+		},
+		NameSerializer: func() string {
+			return fmt.Sprintf("%d,%d,%d PU2XC", i, j, k)
+		},
+		Prefix: cell.BeginCell().MustStoreUInt(0x546, 12).EndCell(),
+		SerializeSuffix: func() *cell.Builder {
+			return cell.BeginCell().
+				MustStoreUInt(uint64(i), 4).
+				MustStoreUInt(uint64(j), 4).
+				MustStoreUInt(uint64(k), 4)
+		},
+		DeserializeSuffix: func(code *cell.Slice) error {
+			ival, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			jval, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			kval, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			i = uint8(ival)
+			j = uint8(jval)
+			k = uint8(kval)
+			return nil
+		},
+	}
+	return op
+}
+
+func PUSH3(i, j, k uint8) (op *helpers.AdvancedOP) {
+	op = &helpers.AdvancedOP{
+		Action: func(state *vm.State) error {
+			val, err := state.Stack.Get(int(i))
+			if err != nil {
+				return err
+			}
+			if err := state.Stack.PushAny(val); err != nil {
+				return err
+			}
+			val, err = state.Stack.Get(int(j) + 1)
+			if err != nil {
+				return err
+			}
+			if err := state.Stack.PushAny(val); err != nil {
+				return err
+			}
+			val, err = state.Stack.Get(int(k) + 2)
+			if err != nil {
+				return err
+			}
+			return state.Stack.PushAny(val)
+		},
+		NameSerializer: func() string {
+			return fmt.Sprintf("%d,%d,%d PUSH3", i, j, k)
+		},
+		Prefix: cell.BeginCell().MustStoreUInt(0x547, 12).EndCell(),
+		SerializeSuffix: func() *cell.Builder {
+			return cell.BeginCell().
+				MustStoreUInt(uint64(i), 4).
+				MustStoreUInt(uint64(j), 4).
+				MustStoreUInt(uint64(k), 4)
+		},
+		DeserializeSuffix: func(code *cell.Slice) error {
+			ival, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			jval, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			kval, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			i = uint8(ival)
+			j = uint8(jval)
+			k = uint8(kval)
+			return nil
+		},
+	}
+	return op
+}

--- a/tvm/op/stack/multi_ops_test.go
+++ b/tvm/op/stack/multi_ops_test.go
@@ -1,0 +1,105 @@
+package stack
+
+import (
+	"testing"
+
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func TestXC2PU(t *testing.T) {
+	st := newStack(1, 2, 3, 4, 5, 6, 7, 8)
+	if err := XC2PU(3, 4, 2).Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("XC2PU failed: %v", err)
+	}
+	got := popInts(t, st, 9)
+	want := []int64{6, 4, 5, 6, 7, 8, 3, 2, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestXCPUXC(t *testing.T) {
+	st := newStack(1, 2, 3, 4, 5, 6, 7, 8)
+	if err := XCPUXC(3, 4, 2).Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("XCPUXC failed: %v", err)
+	}
+	got := popInts(t, st, 9)
+	want := []int64{5, 4, 8, 6, 7, 4, 3, 2, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestXCPU2(t *testing.T) {
+	st := newStack(1, 2, 3, 4, 5, 6, 7, 8)
+	if err := XCPU2(4, 3, 2).Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("XCPU2 failed: %v", err)
+	}
+	got := popInts(t, st, 10)
+	want := []int64{6, 5, 4, 7, 6, 5, 8, 3, 2, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestPUXC2(t *testing.T) {
+	st := newStack(1, 2, 3, 4, 5, 6, 7, 8)
+	if err := PUXC2(4, 3, 2).Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("PUXC2 failed: %v", err)
+	}
+	got := popInts(t, st, 9)
+	want := []int64{4, 6, 7, 8, 5, 4, 3, 2, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestPUXCPU(t *testing.T) {
+	st := newStack(1, 2, 3, 4, 5, 6, 7, 8)
+	if err := PUXCPU(4, 3, 2).Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("PUXCPU failed: %v", err)
+	}
+	got := popInts(t, st, 10)
+	want := []int64{7, 6, 4, 7, 8, 5, 4, 3, 2, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestPU2XC(t *testing.T) {
+	st := newStack(1, 2, 3, 4, 5, 6, 7, 8)
+	if err := PU2XC(4, 3, 2).Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("PU2XC failed: %v", err)
+	}
+	got := popInts(t, st, 10)
+	want := []int64{4, 6, 8, 7, 6, 5, 4, 3, 2, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}
+
+func TestPUSH3(t *testing.T) {
+	st := newStack(1, 2, 3, 4, 5, 6, 7, 8)
+	if err := PUSH3(2, 3, 4).Interpret(&vm.State{Stack: st}); err != nil {
+		t.Fatalf("PUSH3 failed: %v", err)
+	}
+	got := popInts(t, st, 11)
+	want := []int64{4, 5, 6, 8, 7, 6, 5, 4, 3, 2, 1}
+	for i, v := range want {
+		if got[i] != v {
+			t.Fatalf("expected %v, got %v", want, got)
+		}
+	}
+}

--- a/tvm/op/stack/nip.go
+++ b/tvm/op/stack/nip.go
@@ -1,0 +1,20 @@
+package stack
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return NIP() })
+}
+
+func NIP() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Action: func(state *vm.State) error {
+			return state.Stack.PopSwapAt(1)
+		},
+		Name:   "NIP",
+		Prefix: []byte{0x31},
+	}
+}

--- a/tvm/op/stack/only.go
+++ b/tvm/op/stack/only.go
@@ -1,0 +1,46 @@
+package stack
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+	"github.com/xssnick/tonutils-go/tvm/vmerr"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return ONLYTOPX() })
+	vm.List = append(vm.List, func() vm.OP { return ONLYX() })
+}
+
+func ONLYTOPX() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Action: func(state *vm.State) error {
+			count, err := popSmallIndex(state)
+			if err != nil {
+				return err
+			}
+			if count > state.Stack.Len() {
+				return vmerr.Error(vmerr.CodeStackUnderflow)
+			}
+			return state.Stack.DropAfter(count)
+		},
+		Name:   "ONLYTOPX",
+		Prefix: []byte{0x6a},
+	}
+}
+
+func ONLYX() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Action: func(state *vm.State) error {
+			count, err := popSmallIndex(state)
+			if err != nil {
+				return err
+			}
+			if count > state.Stack.Len() {
+				return vmerr.Error(vmerr.CodeStackUnderflow)
+			}
+			return state.Stack.Drop(state.Stack.Len() - count)
+		},
+		Name:   "ONLYX",
+		Prefix: []byte{0x6b},
+	}
+}

--- a/tvm/op/stack/over.go
+++ b/tvm/op/stack/over.go
@@ -1,0 +1,20 @@
+package stack
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return OVER() })
+}
+
+func OVER() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Action: func(state *vm.State) error {
+			return state.Stack.PushAt(1)
+		},
+		Name:   "OVER",
+		Prefix: []byte{0x21},
+	}
+}

--- a/tvm/op/stack/over2.go
+++ b/tvm/op/stack/over2.go
@@ -12,7 +12,7 @@ func init() {
 func OVER2() *helpers.SimpleOP {
 	return &helpers.SimpleOP{
 		Action: func(state *vm.State) error {
-			val, err := state.Stack.Get(int(3))
+			val, err := state.Stack.Get(3)
 			if err != nil {
 				return err
 			}
@@ -25,7 +25,7 @@ func OVER2() *helpers.SimpleOP {
 			}
 			return state.Stack.PushAny(val)
 		},
-		Name:   "OVER2",
+		Name:   "2OVER",
 		Prefix: []byte{0x5D},
 	}
 }

--- a/tvm/op/stack/pick.go
+++ b/tvm/op/stack/pick.go
@@ -1,0 +1,28 @@
+package stack
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+	"github.com/xssnick/tonutils-go/tvm/vmerr"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return PICK() })
+}
+
+func PICK() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Action: func(state *vm.State) error {
+			idx, err := popSmallIndex(state)
+			if err != nil {
+				return err
+			}
+			if idx >= state.Stack.Len() {
+				return vmerr.Error(vmerr.CodeStackUnderflow)
+			}
+			return state.Stack.PushAt(idx)
+		},
+		Name:   "PICK",
+		Prefix: []byte{0x60},
+	}
+}

--- a/tvm/op/stack/poplong.go
+++ b/tvm/op/stack/poplong.go
@@ -1,0 +1,45 @@
+package stack
+
+import (
+	"fmt"
+
+	"github.com/xssnick/tonutils-go/tvm/cell"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+type OpPOPL struct {
+	stackIndex uint8
+}
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return POPL(0) })
+}
+
+func POPL(index uint8) *OpPOPL {
+	return &OpPOPL{stackIndex: index}
+}
+
+func (op *OpPOPL) GetPrefixes() []*cell.Slice {
+	return []*cell.Slice{cell.BeginCell().MustStoreUInt(0x57, 8).EndCell().BeginParse()}
+}
+
+func (op *OpPOPL) Deserialize(code *cell.Slice) error {
+	val, err := code.LoadUInt(8)
+	if err != nil {
+		return err
+	}
+	op.stackIndex = uint8(val)
+	return nil
+}
+
+func (op *OpPOPL) Serialize() *cell.Builder {
+	return cell.BeginCell().MustStoreUInt(0x57, 8).MustStoreUInt(uint64(op.stackIndex), 8)
+}
+
+func (op *OpPOPL) SerializeText() string {
+	return fmt.Sprintf("s%d POP", op.stackIndex)
+}
+
+func (op *OpPOPL) Interpret(state *vm.State) error {
+	return state.Stack.PopSwapAt(int(op.stackIndex))
+}

--- a/tvm/op/stack/pushlong.go
+++ b/tvm/op/stack/pushlong.go
@@ -1,0 +1,45 @@
+package stack
+
+import (
+	"fmt"
+
+	"github.com/xssnick/tonutils-go/tvm/cell"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+type OpPUSHL struct {
+	stackIndex uint8
+}
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return PUSHL(0) })
+}
+
+func PUSHL(index uint8) *OpPUSHL {
+	return &OpPUSHL{stackIndex: index}
+}
+
+func (op *OpPUSHL) GetPrefixes() []*cell.Slice {
+	return []*cell.Slice{cell.BeginCell().MustStoreUInt(0x56, 8).EndCell().BeginParse()}
+}
+
+func (op *OpPUSHL) Deserialize(code *cell.Slice) error {
+	val, err := code.LoadUInt(8)
+	if err != nil {
+		return err
+	}
+	op.stackIndex = uint8(val)
+	return nil
+}
+
+func (op *OpPUSHL) Serialize() *cell.Builder {
+	return cell.BeginCell().MustStoreUInt(0x56, 8).MustStoreUInt(uint64(op.stackIndex), 8)
+}
+
+func (op *OpPUSHL) SerializeText() string {
+	return fmt.Sprintf("s%d PUSH", op.stackIndex)
+}
+
+func (op *OpPUSHL) Interpret(state *vm.State) error {
+	return state.Stack.PushAt(int(op.stackIndex))
+}

--- a/tvm/op/stack/revx.go
+++ b/tvm/op/stack/revx.go
@@ -1,0 +1,35 @@
+package stack
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+	"github.com/xssnick/tonutils-go/tvm/vmerr"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return REVX() })
+}
+
+func REVX() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Action: func(state *vm.State) error {
+			y, err := popSmallIndex(state)
+			if err != nil {
+				return err
+			}
+			x, err := popSmallIndex(state)
+			if err != nil {
+				return err
+			}
+			if x < 0 || y < 0 || x+y > state.Stack.Len() {
+				return vmerr.Error(vmerr.CodeStackUnderflow)
+			}
+			if x == 0 {
+				return nil
+			}
+			return state.Stack.Reverse(x+y-1, y)
+		},
+		Name:   "REVX",
+		Prefix: []byte{0x64},
+	}
+}

--- a/tvm/op/stack/roll.go
+++ b/tvm/op/stack/roll.go
@@ -1,0 +1,34 @@
+package stack
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+	"github.com/xssnick/tonutils-go/tvm/vmerr"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return ROLL() })
+}
+
+func ROLL() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Action: func(state *vm.State) error {
+			idx, err := popSmallIndex(state)
+			if err != nil {
+				return err
+			}
+			if idx >= state.Stack.Len() {
+				return vmerr.Error(vmerr.CodeStackUnderflow)
+			}
+			for idx > 0 {
+				if err := state.Stack.Exchange(idx-1, idx); err != nil {
+					return err
+				}
+				idx--
+			}
+			return nil
+		},
+		Name:   "ROLL",
+		Prefix: []byte{0x61},
+	}
+}

--- a/tvm/op/stack/rollrev.go
+++ b/tvm/op/stack/rollrev.go
@@ -1,0 +1,33 @@
+package stack
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+	"github.com/xssnick/tonutils-go/tvm/vmerr"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return ROLLREV() })
+}
+
+func ROLLREV() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Action: func(state *vm.State) error {
+			idx, err := popSmallIndex(state)
+			if err != nil {
+				return err
+			}
+			if idx >= state.Stack.Len() {
+				return vmerr.Error(vmerr.CodeStackUnderflow)
+			}
+			for i := 0; i < idx; i++ {
+				if err := state.Stack.Exchange(i, i+1); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+		Name:   "ROLLREV",
+		Prefix: []byte{0x62},
+	}
+}

--- a/tvm/op/stack/swap.go
+++ b/tvm/op/stack/swap.go
@@ -1,0 +1,20 @@
+package stack
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return SWAP() })
+}
+
+func SWAP() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Action: func(state *vm.State) error {
+			return state.Stack.Exchange(0, 1)
+		},
+		Name:   "SWAP",
+		Prefix: []byte{0x01},
+	}
+}

--- a/tvm/op/stack/swap2.go
+++ b/tvm/op/stack/swap2.go
@@ -41,7 +41,7 @@ func SWAP2() *helpers.SimpleOP {
 
 			return state.Stack.PushAny(b)
 		},
-		Name:   "SWAP2",
+		Name:   "2SWAP",
 		Prefix: []byte{0x5A},
 	}
 }

--- a/tvm/op/stack/test_helpers_test.go
+++ b/tvm/op/stack/test_helpers_test.go
@@ -1,0 +1,29 @@
+package stack
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func newStack(values ...int64) *vm.Stack {
+	st := vm.NewStack()
+	for _, v := range values {
+		st.PushAny(big.NewInt(v))
+	}
+	return st
+}
+
+func popInts(t *testing.T, st *vm.Stack, count int) []int64 {
+	t.Helper()
+	res := make([]int64, 0, count)
+	for i := 0; i < count; i++ {
+		v, err := st.PopInt()
+		if err != nil {
+			t.Fatalf("failed to pop int: %v", err)
+		}
+		res = append(res, v.Int64())
+	}
+	return res
+}

--- a/tvm/op/stack/xchg0_long.go
+++ b/tvm/op/stack/xchg0_long.go
@@ -1,0 +1,37 @@
+package stack
+
+import (
+	"fmt"
+
+	"github.com/xssnick/tonutils-go/tvm/cell"
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return XCHG0L(0) })
+}
+
+func XCHG0L(i uint8) (op *helpers.AdvancedOP) {
+	op = &helpers.AdvancedOP{
+		Action: func(state *vm.State) error {
+			return state.Stack.Exchange(0, int(i))
+		},
+		NameSerializer: func() string {
+			return fmt.Sprintf("%d XCHG0", i)
+		},
+		Prefix: cell.BeginCell().MustStoreUInt(0x11, 8).EndCell(),
+		SerializeSuffix: func() *cell.Builder {
+			return cell.BeginCell().MustStoreUInt(uint64(i), 8)
+		},
+		DeserializeSuffix: func(code *cell.Slice) error {
+			val, err := code.LoadUInt(8)
+			if err != nil {
+				return err
+			}
+			i = uint8(val)
+			return nil
+		},
+	}
+	return op
+}

--- a/tvm/op/stack/xchg3.go
+++ b/tvm/op/stack/xchg3.go
@@ -27,7 +27,7 @@ func XCHG3(i, j, k uint8) (op *helpers.AdvancedOP) {
 		NameSerializer: func() string {
 			return fmt.Sprintf("%d,%d,%d XCHG3", i, j, k)
 		},
-                Prefix: cell.BeginCell().MustStoreUInt(0x4, 4).EndCell(),
+		Prefix: cell.BeginCell().MustStoreUInt(0x4, 4).EndCell(),
 		SerializeSuffix: func() *cell.Builder {
 			return cell.BeginCell().MustStoreUInt(uint64(i), 4).MustStoreUInt(uint64(j), 4).MustStoreUInt(uint64(k), 4)
 		},

--- a/tvm/op/stack/xchgx.go
+++ b/tvm/op/stack/xchgx.go
@@ -1,0 +1,24 @@
+package stack
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return XCHGX() })
+}
+
+func XCHGX() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Action: func(state *vm.State) error {
+			idx, err := popSmallIndex(state)
+			if err != nil {
+				return err
+			}
+			return state.Stack.Exchange(0, idx)
+		},
+		Name:   "XCHGX",
+		Prefix: []byte{0x67},
+	}
+}


### PR DESCRIPTION
## Summary
- add TVM stack manipulation instructions (PICK/ROLL/ROLLREV/BLKSWX/REVX/DROPX/ONLYTOPX/ONLYX/XCHGX/DEPTH/CHKDEPTH) with shared small-index helper
- implement long and multi-operand stack opcodes (XCHG0L/PUSHL/POPL and XC2PU/XCPUXC/XCPU2/PUXC2/PUXCPU/PU2XC/PUSH3)
- adjust existing 2* ops naming, wire new SWAP/DUP/OVER/NIP handlers, and cover everything with unit tests

## Testing
- go test ./tvm/op/stack -run Test -count=1

------
https://chatgpt.com/codex/tasks/task_e_68d00145d5408320bc7d241c409ac9da