### PR TITLE
Refactor tuple opcodes into separate files

### DIFF
--- a/tvm/op/tuple/explode.go
+++ b/tvm/op/tuple/explode.go
@@ -1,0 +1,57 @@
+package tuple
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/xssnick/tonutils-go/tvm/cell"
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return EXPLODE(0) })
+}
+
+func EXPLODE(n uint8) *helpers.AdvancedOP {
+	return &helpers.AdvancedOP{
+		Prefix: cell.BeginCell().MustStoreUInt(0x6f4, 12).EndCell(),
+		NameSerializer: func() string {
+			return fmt.Sprintf("%d EXPLODE", n)
+		},
+		SerializeSuffix: func() *cell.Builder {
+			return cell.BeginCell().MustStoreUInt(uint64(n), 4)
+		},
+		DeserializeSuffix: func(code *cell.Slice) error {
+			val, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			n = uint8(val)
+			return nil
+		},
+		Action: func(state *vm.State) error {
+			return execExplode(state, int(n))
+		},
+	}
+}
+
+func execExplode(state *vm.State, max int) error {
+	tup, err := state.Stack.PopTupleRange(max)
+	if err != nil {
+		return err
+	}
+
+	length := tup.Len()
+	for i := 0; i < length; i++ {
+		val, err := tup.Index(i)
+		if err != nil {
+			return err
+		}
+		if err = state.Stack.PushAny(val); err != nil {
+			return err
+		}
+	}
+
+	return state.Stack.PushInt(big.NewInt(int64(length)))
+}

--- a/tvm/op/tuple/explodevar.go
+++ b/tvm/op/tuple/explodevar.go
@@ -1,0 +1,24 @@
+package tuple
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return EXPLODEVAR() })
+}
+
+func EXPLODEVAR() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Name:   "EXPLODEVAR",
+		Prefix: []byte{0x6f, 0x84},
+		Action: func(state *vm.State) error {
+			max, err := state.Stack.PopIntRange(0, 255)
+			if err != nil {
+				return err
+			}
+			return execExplode(state, int(max.Int64()))
+		},
+	}
+}

--- a/tvm/op/tuple/index.go
+++ b/tvm/op/tuple/index.go
@@ -1,0 +1,44 @@
+package tuple
+
+import (
+	"fmt"
+
+	"github.com/xssnick/tonutils-go/tvm/cell"
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return INDEX(0) })
+}
+
+func INDEX(n uint8) *helpers.AdvancedOP {
+	return &helpers.AdvancedOP{
+		Prefix: cell.BeginCell().MustStoreUInt(0x6f1, 12).EndCell(),
+		NameSerializer: func() string {
+			return fmt.Sprintf("%d INDEX", n)
+		},
+		SerializeSuffix: func() *cell.Builder {
+			return cell.BeginCell().MustStoreUInt(uint64(n), 4)
+		},
+		DeserializeSuffix: func(code *cell.Slice) error {
+			val, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			n = uint8(val)
+			return nil
+		},
+		Action: func(state *vm.State) error {
+			tup, err := state.Stack.PopTupleRange(255)
+			if err != nil {
+				return err
+			}
+			v, err := tup.Index(int(n))
+			if err != nil {
+				return err
+			}
+			return state.Stack.PushAny(v)
+		},
+	}
+}

--- a/tvm/op/tuple/index2.go
+++ b/tvm/op/tuple/index2.go
@@ -1,0 +1,99 @@
+package tuple
+
+import (
+	"fmt"
+
+	"github.com/xssnick/tonutils-go/tvm/cell"
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	tuplepkg "github.com/xssnick/tonutils-go/tvm/tuple"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+	"github.com/xssnick/tonutils-go/tvm/vmerr"
+)
+
+func init() {
+	vm.List = append(vm.List,
+		func() vm.OP { return INDEX2(0, 0) },
+		func() vm.OP { return INDEX3(0, 0, 0) },
+	)
+}
+
+func INDEX2(i, j uint8) *helpers.AdvancedOP {
+	return &helpers.AdvancedOP{
+		Prefix: cell.BeginCell().MustStoreUInt(0x6fb, 12).EndCell(),
+		NameSerializer: func() string {
+			return fmt.Sprintf("INDEX2 %d,%d", i, j)
+		},
+		SerializeSuffix: func() *cell.Builder {
+			value := (uint64(i&3) << 2) | uint64(j&3)
+			return cell.BeginCell().MustStoreUInt(value, 4)
+		},
+		DeserializeSuffix: func(code *cell.Slice) error {
+			val, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			i = uint8((val >> 2) & 3)
+			j = uint8(val & 3)
+			return nil
+		},
+		Action: func(state *vm.State) error {
+			return execIndexMulti(state, []int{int(i), int(j)})
+		},
+	}
+}
+
+func INDEX3(i, j, k uint8) *helpers.AdvancedOP {
+	return &helpers.AdvancedOP{
+		Prefix: cell.BeginCell().MustStoreUInt(0x6fc>>2, 10).EndCell(),
+		NameSerializer: func() string {
+			return fmt.Sprintf("INDEX3 %d,%d,%d", i, j, k)
+		},
+		SerializeSuffix: func() *cell.Builder {
+			value := (uint64(i&3) << 4) | (uint64(j&3) << 2) | uint64(k&3)
+			return cell.BeginCell().MustStoreUInt(value, 6)
+		},
+		DeserializeSuffix: func(code *cell.Slice) error {
+			val, err := code.LoadUInt(6)
+			if err != nil {
+				return err
+			}
+			i = uint8((val >> 4) & 3)
+			j = uint8((val >> 2) & 3)
+			k = uint8(val & 3)
+			return nil
+		},
+		Action: func(state *vm.State) error {
+			return execIndexMulti(state, []int{int(i), int(j), int(k)})
+		},
+	}
+}
+
+func execIndexMulti(state *vm.State, indices []int) error {
+	tup, err := state.Stack.PopTupleRange(255)
+	if err != nil {
+		return err
+	}
+
+	current := tup
+	for idx := 0; idx < len(indices)-1; idx++ {
+		val, err := current.Index(indices[idx])
+		if err != nil {
+			return err
+		}
+		nested, ok := val.(tuplepkg.Tuple)
+		if !ok {
+			return vmerr.Error(vmerr.CodeTypeCheck, "intermediate value is not a tuple")
+		}
+		if nested.Len() > 255 {
+			return vmerr.Error(vmerr.CodeTypeCheck, "not a tuple of valid size")
+		}
+		current = nested
+	}
+
+	val, err := current.Index(indices[len(indices)-1])
+	if err != nil {
+		return err
+	}
+
+	return state.Stack.PushAny(val)
+}

--- a/tvm/op/tuple/indexq.go
+++ b/tvm/op/tuple/indexq.go
@@ -1,0 +1,51 @@
+package tuple
+
+import (
+	"fmt"
+
+	"github.com/xssnick/tonutils-go/tvm/cell"
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return INDEXQ(0) })
+}
+
+func INDEXQ(n uint8) *helpers.AdvancedOP {
+	return &helpers.AdvancedOP{
+		Prefix: cell.BeginCell().MustStoreUInt(0x6f6, 12).EndCell(),
+		NameSerializer: func() string {
+			return fmt.Sprintf("%d INDEXQ", n)
+		},
+		SerializeSuffix: func() *cell.Builder {
+			return cell.BeginCell().MustStoreUInt(uint64(n), 4)
+		},
+		DeserializeSuffix: func(code *cell.Slice) error {
+			val, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			n = uint8(val)
+			return nil
+		},
+		Action: func(state *vm.State) error {
+			return execIndexQuiet(state, int(n))
+		},
+	}
+}
+
+func execIndexQuiet(state *vm.State, idx int) error {
+	tup, err := state.Stack.PopMaybeTupleRange(255)
+	if err != nil {
+		return err
+	}
+	if tup == nil || idx >= tup.Len() || idx < 0 {
+		return state.Stack.PushAny(nil)
+	}
+	val, err := tup.Index(idx)
+	if err != nil {
+		return err
+	}
+	return state.Stack.PushAny(val)
+}

--- a/tvm/op/tuple/indexvar.go
+++ b/tvm/op/tuple/indexvar.go
@@ -1,0 +1,32 @@
+package tuple
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return INDEXVAR() })
+}
+
+func INDEXVAR() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Name:   "INDEXVAR",
+		Prefix: []byte{0x6f, 0x81},
+		Action: func(state *vm.State) error {
+			idx, err := state.Stack.PopIntRange(0, 254)
+			if err != nil {
+				return err
+			}
+			tup, err := state.Stack.PopTupleRange(255)
+			if err != nil {
+				return err
+			}
+			v, err := tup.Index(int(idx.Int64()))
+			if err != nil {
+				return err
+			}
+			return state.Stack.PushAny(v)
+		},
+	}
+}

--- a/tvm/op/tuple/indexvarq.go
+++ b/tvm/op/tuple/indexvarq.go
@@ -1,0 +1,24 @@
+package tuple
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return INDEXVARQ() })
+}
+
+func INDEXVARQ() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Name:   "INDEXVARQ",
+		Prefix: []byte{0x6f, 0x86},
+		Action: func(state *vm.State) error {
+			idx, err := state.Stack.PopIntRange(0, 254)
+			if err != nil {
+				return err
+			}
+			return execIndexQuiet(state, int(idx.Int64()))
+		},
+	}
+}

--- a/tvm/op/tuple/isnull.go
+++ b/tvm/op/tuple/isnull.go
@@ -1,0 +1,24 @@
+package tuple
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return ISNULL() })
+}
+
+func ISNULL() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Name:   "ISNULL",
+		Prefix: []byte{0x6e},
+		Action: func(state *vm.State) error {
+			val, err := state.Stack.PopAny()
+			if err != nil {
+				return err
+			}
+			return state.Stack.PushBool(val == nil)
+		},
+	}
+}

--- a/tvm/op/tuple/istuple.go
+++ b/tvm/op/tuple/istuple.go
@@ -1,0 +1,26 @@
+package tuple
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	tuplepkg "github.com/xssnick/tonutils-go/tvm/tuple"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return ISTUPLE() })
+}
+
+func ISTUPLE() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Name:   "ISTUPLE",
+		Prefix: []byte{0x6f, 0x8a},
+		Action: func(state *vm.State) error {
+			val, err := state.Stack.PopAny()
+			if err != nil {
+				return err
+			}
+			_, ok := val.(tuplepkg.Tuple)
+			return state.Stack.PushBool(ok)
+		},
+	}
+}

--- a/tvm/op/tuple/last.go
+++ b/tvm/op/tuple/last.go
@@ -1,0 +1,28 @@
+package tuple
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return LAST() })
+}
+
+func LAST() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Name:   "LAST",
+		Prefix: []byte{0x6f, 0x8b},
+		Action: func(state *vm.State) error {
+			tup, err := state.Stack.PopTupleRange(255, 1)
+			if err != nil {
+				return err
+			}
+			val, err := tup.Index(tup.Len() - 1)
+			if err != nil {
+				return err
+			}
+			return state.Stack.PushAny(val)
+		},
+	}
+}

--- a/tvm/op/tuple/nullops.go
+++ b/tvm/op/tuple/nullops.go
@@ -1,0 +1,85 @@
+package tuple
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+	"github.com/xssnick/tonutils-go/tvm/vmerr"
+)
+
+func init() {
+	vm.List = append(vm.List,
+		func() vm.OP { return NULLSWAPIF() },
+		func() vm.OP { return NULLSWAPIFNOT() },
+		func() vm.OP { return NULLROTRIF() },
+		func() vm.OP { return NULLROTRIFNOT() },
+		func() vm.OP { return NULLSWAPIF2() },
+		func() vm.OP { return NULLSWAPIFNOT2() },
+		func() vm.OP { return NULLROTRIF2() },
+		func() vm.OP { return NULLROTRIFNOT2() },
+	)
+}
+
+func NULLSWAPIF() *helpers.SimpleOP {
+	return makeNullOp("NULLSWAPIF", 0x6fa0, true, 0, 1)
+}
+
+func NULLSWAPIFNOT() *helpers.SimpleOP {
+	return makeNullOp("NULLSWAPIFNOT", 0x6fa1, false, 0, 1)
+}
+
+func NULLROTRIF() *helpers.SimpleOP {
+	return makeNullOp("NULLROTRIF", 0x6fa2, true, 1, 1)
+}
+
+func NULLROTRIFNOT() *helpers.SimpleOP {
+	return makeNullOp("NULLROTRIFNOT", 0x6fa3, false, 1, 1)
+}
+
+func NULLSWAPIF2() *helpers.SimpleOP {
+	return makeNullOp("NULLSWAPIF2", 0x6fa4, true, 0, 2)
+}
+
+func NULLSWAPIFNOT2() *helpers.SimpleOP {
+	return makeNullOp("NULLSWAPIFNOT2", 0x6fa5, false, 0, 2)
+}
+
+func NULLROTRIF2() *helpers.SimpleOP {
+	return makeNullOp("NULLROTRIF2", 0x6fa6, true, 1, 2)
+}
+
+func NULLROTRIFNOT2() *helpers.SimpleOP {
+	return makeNullOp("NULLROTRIFNOT2", 0x6fa7, false, 1, 2)
+}
+
+func makeNullOp(name string, prefix uint64, cond bool, depth, count int) *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Name:   name,
+		Prefix: []byte{byte(prefix >> 8), byte(prefix)},
+		Action: func(state *vm.State) error {
+			if state.Stack.Len() < depth+1 {
+				return vmerr.Error(vmerr.CodeStackUnderflow)
+			}
+
+			x, err := state.Stack.PopIntFinite()
+			if err != nil {
+				return err
+			}
+
+			should := (x.Sign() == 0) != cond
+			if should {
+				for i := 0; i < count; i++ {
+					if err = state.Stack.PushAny(nil); err != nil {
+						return err
+					}
+				}
+				for i := 0; i < depth; i++ {
+					if err = state.Stack.Exchange(i, i+count); err != nil {
+						return err
+					}
+				}
+			}
+
+			return state.Stack.PushInt(x)
+		},
+	}
+}

--- a/tvm/op/tuple/ops_test.go
+++ b/tvm/op/tuple/ops_test.go
@@ -1,0 +1,584 @@
+package tuple
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	tuplepkg "github.com/xssnick/tonutils-go/tvm/tuple"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func newState() *vm.State {
+	return &vm.State{Stack: vm.NewStack()}
+}
+
+func pushInts(t *testing.T, state *vm.State, values ...int64) {
+	t.Helper()
+	for _, v := range values {
+		if err := state.Stack.PushInt(big.NewInt(v)); err != nil {
+			t.Fatalf("failed to push int: %v", err)
+		}
+	}
+}
+
+func popInt(t *testing.T, state *vm.State) int64 {
+	t.Helper()
+	val, err := state.Stack.PopInt()
+	if err != nil {
+		t.Fatalf("failed to pop int: %v", err)
+	}
+	return val.Int64()
+}
+
+func popAny(t *testing.T, state *vm.State) any {
+	t.Helper()
+	val, err := state.Stack.PopAny()
+	if err != nil {
+		t.Fatalf("failed to pop value: %v", err)
+	}
+	return val
+}
+
+func TestPushNullAndIsNull(t *testing.T) {
+	state := newState()
+
+	if err := PUSHNULL().Interpret(state); err != nil {
+		t.Fatalf("PUSHNULL failed: %v", err)
+	}
+	if val := popAny(t, state); val != nil {
+		t.Fatalf("expected nil on stack, got %v", val)
+	}
+
+	if err := state.Stack.PushAny(nil); err != nil {
+		t.Fatalf("failed to push nil: %v", err)
+	}
+	if err := ISNULL().Interpret(state); err != nil {
+		t.Fatalf("ISNULL failed: %v", err)
+	}
+	boolVal, err := state.Stack.PopBool()
+	if err != nil {
+		t.Fatalf("failed to pop bool: %v", err)
+	}
+	if !boolVal {
+		t.Fatalf("expected true from ISNULL on nil")
+	}
+
+	if err := state.Stack.PushInt(big.NewInt(7)); err != nil {
+		t.Fatalf("failed to push int: %v", err)
+	}
+	if err := ISNULL().Interpret(state); err != nil {
+		t.Fatalf("ISNULL failed: %v", err)
+	}
+	boolVal, err = state.Stack.PopBool()
+	if err != nil {
+		t.Fatalf("failed to pop bool: %v", err)
+	}
+	if boolVal {
+		t.Fatalf("expected false from ISNULL on non-nil")
+	}
+}
+
+func TestTupleCreationAndIndexing(t *testing.T) {
+	state := newState()
+
+	pushInts(t, state, 1, 2, 3)
+	if err := TUPLE(3).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+
+	val, err := state.Stack.Get(0)
+	if err != nil {
+		t.Fatalf("failed to get tuple: %v", err)
+	}
+	tup, ok := val.(tuplepkg.Tuple)
+	if !ok {
+		t.Fatalf("expected tuple on stack, got %T", val)
+	}
+	for i, expected := range []int64{1, 2, 3} {
+		item, err := tup.Index(i)
+		if err != nil {
+			t.Fatalf("tuple index failed: %v", err)
+		}
+		got := item.(*big.Int).Int64()
+		if got != expected {
+			t.Fatalf("tuple[%d] = %d, want %d", i, got, expected)
+		}
+	}
+
+	if err := INDEX(1).Interpret(state); err != nil {
+		t.Fatalf("INDEX failed: %v", err)
+	}
+	if got := popInt(t, state); got != 2 {
+		t.Fatalf("INDEX returned %d, want 2", got)
+	}
+
+	pushInts(t, state, 4, 5, 6)
+	if err := TUPLE(3).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+	if err := INDEXQ(5).Interpret(state); err != nil {
+		t.Fatalf("INDEXQ failed: %v", err)
+	}
+	if val := popAny(t, state); val != nil {
+		t.Fatalf("INDEXQ out of range expected nil, got %v", val)
+	}
+
+	pushInts(t, state, 7, 8, 9)
+	if err := TUPLE(3).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+	if err := INDEXQ(2).Interpret(state); err != nil {
+		t.Fatalf("INDEXQ failed: %v", err)
+	}
+	if got := popInt(t, state); got != 9 {
+		t.Fatalf("INDEXQ returned %d, want 9", got)
+	}
+
+	pushInts(t, state, 11, 12, 13)
+	if err := TUPLE(3).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+	if err := state.Stack.PushInt(big.NewInt(1)); err != nil {
+		t.Fatalf("failed to push index: %v", err)
+	}
+	if err := INDEXVAR().Interpret(state); err != nil {
+		t.Fatalf("INDEXVAR failed: %v", err)
+	}
+	if got := popInt(t, state); got != 12 {
+		t.Fatalf("INDEXVAR returned %d, want 12", got)
+	}
+
+	pushInts(t, state, 21, 22, 23)
+	if err := TUPLE(3).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+	if err := state.Stack.PushInt(big.NewInt(5)); err != nil {
+		t.Fatalf("failed to push index: %v", err)
+	}
+	if err := INDEXVARQ().Interpret(state); err != nil {
+		t.Fatalf("INDEXVARQ failed: %v", err)
+	}
+	if val := popAny(t, state); val != nil {
+		t.Fatalf("INDEXVARQ out of range expected nil, got %v", val)
+	}
+}
+
+func TestTupleSetOperations(t *testing.T) {
+	state := newState()
+
+	pushInts(t, state, 1, 2, 3)
+	if err := TUPLE(3).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+	if err := state.Stack.PushInt(big.NewInt(99)); err != nil {
+		t.Fatalf("failed to push value: %v", err)
+	}
+	if err := SETINDEX(1).Interpret(state); err != nil {
+		t.Fatalf("SETINDEX failed: %v", err)
+	}
+	updated := popAny(t, state)
+	tup, ok := updated.(tuplepkg.Tuple)
+	if !ok {
+		t.Fatalf("expected tuple result, got %T", updated)
+	}
+	item, err := tup.Index(1)
+	if err != nil {
+		t.Fatalf("tuple index failed: %v", err)
+	}
+	if got := item.(*big.Int).Int64(); got != 99 {
+		t.Fatalf("SETINDEX produced %d, want 99", got)
+	}
+
+	pushInts(t, state, 4, 5, 6)
+	if err := TUPLE(3).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+	if err := state.Stack.PushInt(big.NewInt(77)); err != nil {
+		t.Fatalf("failed to push value: %v", err)
+	}
+	if err := state.Stack.PushInt(big.NewInt(2)); err != nil {
+		t.Fatalf("failed to push index: %v", err)
+	}
+	if err := SETINDEXVAR().Interpret(state); err != nil {
+		t.Fatalf("SETINDEXVAR failed: %v", err)
+	}
+	updated = popAny(t, state)
+	tup, ok = updated.(tuplepkg.Tuple)
+	if !ok {
+		t.Fatalf("expected tuple result, got %T", updated)
+	}
+	item, err = tup.Index(2)
+	if err != nil {
+		t.Fatalf("tuple index failed: %v", err)
+	}
+	if got := item.(*big.Int).Int64(); got != 77 {
+		t.Fatalf("SETINDEXVAR produced %d, want 77", got)
+	}
+
+	pushInts(t, state, 8)
+	if err := TUPLE(1).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+	if err := state.Stack.PushInt(big.NewInt(55)); err != nil {
+		t.Fatalf("failed to push value: %v", err)
+	}
+	if err := SETINDEXQ(3).Interpret(state); err != nil {
+		t.Fatalf("SETINDEXQ failed: %v", err)
+	}
+	updated = popAny(t, state)
+	tup, ok = updated.(tuplepkg.Tuple)
+	if !ok {
+		t.Fatalf("expected tuple result, got %T", updated)
+	}
+	if tup.Len() != 4 {
+		t.Fatalf("expected tuple length 4, got %d", tup.Len())
+	}
+	item, err = tup.Index(3)
+	if err != nil {
+		t.Fatalf("tuple index failed: %v", err)
+	}
+	if got := item.(*big.Int).Int64(); got != 55 {
+		t.Fatalf("SETINDEXQ produced %d, want 55", got)
+	}
+
+	if err := state.Stack.PushAny(nil); err != nil {
+		t.Fatalf("failed to push nil tuple: %v", err)
+	}
+	if err := state.Stack.PushAny(nil); err != nil {
+		t.Fatalf("failed to push nil value: %v", err)
+	}
+	if err := state.Stack.PushInt(big.NewInt(1)); err != nil {
+		t.Fatalf("failed to push index: %v", err)
+	}
+	if err := SETINDEXVARQ().Interpret(state); err != nil {
+		t.Fatalf("SETINDEXVARQ failed: %v", err)
+	}
+	if val := popAny(t, state); val != nil {
+		t.Fatalf("SETINDEXVARQ with nil inputs expected nil, got %v", val)
+	}
+}
+
+func TestTupleUnpackAndExplode(t *testing.T) {
+	state := newState()
+
+	pushInts(t, state, 1, 2, 3)
+	if err := TUPLE(3).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+	if err := UNTUPLE(3).Interpret(state); err != nil {
+		t.Fatalf("UNTUPLE failed: %v", err)
+	}
+	if got := popInt(t, state); got != 3 {
+		t.Fatalf("UNTUPLE expected last element 3, got %d", got)
+	}
+	if got := popInt(t, state); got != 2 {
+		t.Fatalf("UNTUPLE expected second element 2, got %d", got)
+	}
+	if got := popInt(t, state); got != 1 {
+		t.Fatalf("UNTUPLE expected first element 1, got %d", got)
+	}
+
+	pushInts(t, state, 4, 5, 6)
+	if err := TUPLE(3).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+	if err := UNPACKFIRST(2).Interpret(state); err != nil {
+		t.Fatalf("UNPACKFIRST failed: %v", err)
+	}
+	if got := popInt(t, state); got != 5 {
+		t.Fatalf("UNPACKFIRST expected second element 5, got %d", got)
+	}
+	if got := popInt(t, state); got != 4 {
+		t.Fatalf("UNPACKFIRST expected first element 4, got %d", got)
+	}
+
+	pushInts(t, state, 7, 8)
+	if err := TUPLE(2).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+	if err := EXPLODE(2).Interpret(state); err != nil {
+		t.Fatalf("EXPLODE failed: %v", err)
+	}
+	if got := popInt(t, state); got != 2 {
+		t.Fatalf("EXPLODE length expected 2, got %d", got)
+	}
+	if got := popInt(t, state); got != 8 {
+		t.Fatalf("EXPLODE expected second element 8, got %d", got)
+	}
+	if got := popInt(t, state); got != 7 {
+		t.Fatalf("EXPLODE expected first element 7, got %d", got)
+	}
+
+	pushInts(t, state, 9, 10, 11)
+	if err := TUPLE(3).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+	if err := state.Stack.PushInt(big.NewInt(3)); err != nil {
+		t.Fatalf("failed to push count: %v", err)
+	}
+	if err := UNTUPLEVAR().Interpret(state); err != nil {
+		t.Fatalf("UNTUPLEVAR failed: %v", err)
+	}
+	if got := popInt(t, state); got != 11 {
+		t.Fatalf("UNTUPLEVAR expected last element 11, got %d", got)
+	}
+	if got := popInt(t, state); got != 10 {
+		t.Fatalf("UNTUPLEVAR expected second element 10, got %d", got)
+	}
+	if got := popInt(t, state); got != 9 {
+		t.Fatalf("UNTUPLEVAR expected first element 9, got %d", got)
+	}
+
+	pushInts(t, state, 12, 13, 14)
+	if err := TUPLE(3).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+	if err := state.Stack.PushInt(big.NewInt(2)); err != nil {
+		t.Fatalf("failed to push count: %v", err)
+	}
+	if err := UNPACKFIRSTVAR().Interpret(state); err != nil {
+		t.Fatalf("UNPACKFIRSTVAR failed: %v", err)
+	}
+	if got := popInt(t, state); got != 13 {
+		t.Fatalf("UNPACKFIRSTVAR expected second element 13, got %d", got)
+	}
+	if got := popInt(t, state); got != 12 {
+		t.Fatalf("UNPACKFIRSTVAR expected first element 12, got %d", got)
+	}
+
+	pushInts(t, state, 15, 16)
+	if err := TUPLE(2).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+	if err := state.Stack.PushInt(big.NewInt(2)); err != nil {
+		t.Fatalf("failed to push max: %v", err)
+	}
+	if err := EXPLODEVAR().Interpret(state); err != nil {
+		t.Fatalf("EXPLODEVAR failed: %v", err)
+	}
+	if got := popInt(t, state); got != 2 {
+		t.Fatalf("EXPLODEVAR length expected 2, got %d", got)
+	}
+	if got := popInt(t, state); got != 16 {
+		t.Fatalf("EXPLODEVAR expected second element 16, got %d", got)
+	}
+	if got := popInt(t, state); got != 15 {
+		t.Fatalf("EXPLODEVAR expected first element 15, got %d", got)
+	}
+}
+
+func TestTupleLengthAndLast(t *testing.T) {
+	state := newState()
+
+	pushInts(t, state, 1, 2, 3)
+	if err := TUPLE(3).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+	if err := TLEN().Interpret(state); err != nil {
+		t.Fatalf("TLEN failed: %v", err)
+	}
+	if got := popInt(t, state); got != 3 {
+		t.Fatalf("TLEN returned %d, want 3", got)
+	}
+
+	pushInts(t, state, 4, 5)
+	if err := TUPLE(2).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+	if err := QTLEN().Interpret(state); err != nil {
+		t.Fatalf("QTLEN failed: %v", err)
+	}
+	if got := popInt(t, state); got != 2 {
+		t.Fatalf("QTLEN tuple expected 2, got %d", got)
+	}
+
+	if err := state.Stack.PushInt(big.NewInt(10)); err != nil {
+		t.Fatalf("failed to push int: %v", err)
+	}
+	if err := QTLEN().Interpret(state); err != nil {
+		t.Fatalf("QTLEN failed on non-tuple: %v", err)
+	}
+	if got := popInt(t, state); got != -1 {
+		t.Fatalf("QTLEN non-tuple expected -1, got %d", got)
+	}
+
+	pushInts(t, state, 6, 7, 8)
+	if err := TUPLE(3).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+	if err := ISTUPLE().Interpret(state); err != nil {
+		t.Fatalf("ISTUPLE failed: %v", err)
+	}
+	boolVal, err := state.Stack.PopBool()
+	if err != nil {
+		t.Fatalf("failed to pop bool: %v", err)
+	}
+	if !boolVal {
+		t.Fatalf("ISTUPLE expected true for tuple")
+	}
+
+	if err := state.Stack.PushInt(big.NewInt(1)); err != nil {
+		t.Fatalf("failed to push int: %v", err)
+	}
+	if err := ISTUPLE().Interpret(state); err != nil {
+		t.Fatalf("ISTUPLE failed on non-tuple: %v", err)
+	}
+	boolVal, err = state.Stack.PopBool()
+	if err != nil {
+		t.Fatalf("failed to pop bool: %v", err)
+	}
+	if boolVal {
+		t.Fatalf("ISTUPLE expected false for non-tuple")
+	}
+
+	pushInts(t, state, 9, 10, 11)
+	if err := TUPLE(3).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+	if err := LAST().Interpret(state); err != nil {
+		t.Fatalf("LAST failed: %v", err)
+	}
+	if got := popInt(t, state); got != 11 {
+		t.Fatalf("LAST returned %d, want 11", got)
+	}
+}
+
+func TestTuplePushAndPop(t *testing.T) {
+	state := newState()
+
+	pushInts(t, state, 1, 2)
+	if err := TUPLE(2).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+	if err := state.Stack.PushInt(big.NewInt(3)); err != nil {
+		t.Fatalf("failed to push value: %v", err)
+	}
+	if err := TPUSH().Interpret(state); err != nil {
+		t.Fatalf("TPUSH failed: %v", err)
+	}
+	updated := popAny(t, state)
+	tup, ok := updated.(tuplepkg.Tuple)
+	if !ok {
+		t.Fatalf("expected tuple after TPUSH, got %T", updated)
+	}
+	if tup.Len() != 3 {
+		t.Fatalf("TPUSH expected tuple length 3, got %d", tup.Len())
+	}
+	item, err := tup.Index(2)
+	if err != nil {
+		t.Fatalf("tuple index failed: %v", err)
+	}
+	if got := item.(*big.Int).Int64(); got != 3 {
+		t.Fatalf("TPUSH appended %d, want 3", got)
+	}
+
+	pushInts(t, state, 4, 5, 6)
+	if err := TUPLE(3).Interpret(state); err != nil {
+		t.Fatalf("TUPLE failed: %v", err)
+	}
+	if err := TPOP().Interpret(state); err != nil {
+		t.Fatalf("TPOP failed: %v", err)
+	}
+	if got := popInt(t, state); got != 6 {
+		t.Fatalf("TPOP value expected 6, got %d", got)
+	}
+	updated = popAny(t, state)
+	tup, ok = updated.(tuplepkg.Tuple)
+	if !ok {
+		t.Fatalf("expected tuple after TPOP, got %T", updated)
+	}
+	if tup.Len() != 2 {
+		t.Fatalf("TPOP expected tuple length 2, got %d", tup.Len())
+	}
+}
+
+func TestTupleNullOperations(t *testing.T) {
+	tests := []struct {
+		name     string
+		op       func() *helpers.SimpleOP
+		cond     int64
+		initial  []int64
+		expected []any
+	}{
+		{"NULLSWAPIF", func() *helpers.SimpleOP { return NULLSWAPIF() }, 1, []int64{7}, []any{int64(1), nil, int64(7)}},
+		{"NULLSWAPIFNOT", func() *helpers.SimpleOP { return NULLSWAPIFNOT() }, 0, []int64{7}, []any{int64(0), nil, int64(7)}},
+		{"NULLROTRIF", func() *helpers.SimpleOP { return NULLROTRIF() }, 1, []int64{3, 4}, []any{int64(1), int64(4), nil, int64(3)}},
+		{"NULLROTRIFNOT", func() *helpers.SimpleOP { return NULLROTRIFNOT() }, 0, []int64{3, 4}, []any{int64(0), int64(4), nil, int64(3)}},
+		{"NULLSWAPIF2", func() *helpers.SimpleOP { return NULLSWAPIF2() }, 1, []int64{5}, []any{int64(1), nil, nil, int64(5)}},
+		{"NULLSWAPIFNOT2", func() *helpers.SimpleOP { return NULLSWAPIFNOT2() }, 0, []int64{5}, []any{int64(0), nil, nil, int64(5)}},
+		{"NULLROTRIF2", func() *helpers.SimpleOP { return NULLROTRIF2() }, 1, []int64{8, 9}, []any{int64(1), int64(9), nil, nil, int64(8)}},
+		{"NULLROTRIFNOT2", func() *helpers.SimpleOP { return NULLROTRIFNOT2() }, 0, []int64{8, 9}, []any{int64(0), int64(9), nil, nil, int64(8)}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := newState()
+			for _, v := range tt.initial {
+				if err := state.Stack.PushInt(big.NewInt(v)); err != nil {
+					t.Fatalf("failed to push initial value: %v", err)
+				}
+			}
+			if err := state.Stack.PushInt(big.NewInt(tt.cond)); err != nil {
+				t.Fatalf("failed to push condition: %v", err)
+			}
+			if err := tt.op().Interpret(state); err != nil {
+				t.Fatalf("operation failed: %v", err)
+			}
+			for _, exp := range tt.expected {
+				val := popAny(t, state)
+				switch expected := exp.(type) {
+				case nil:
+					if val != nil {
+						t.Fatalf("expected nil, got %v", val)
+					}
+				case int64:
+					intVal, ok := val.(*big.Int)
+					if !ok {
+						t.Fatalf("expected int, got %T", val)
+					}
+					if intVal.Int64() != expected {
+						t.Fatalf("expected %d, got %d", expected, intVal.Int64())
+					}
+				default:
+					t.Fatalf("unexpected expected type %T", exp)
+				}
+			}
+			if state.Stack.Len() != 0 {
+				t.Fatalf("expected empty stack, got len %d", state.Stack.Len())
+			}
+		})
+	}
+}
+
+func TestTupleIndex2AndIndex3(t *testing.T) {
+	state := newState()
+
+	inner1 := tuplepkg.NewTuple(big.NewInt(1), big.NewInt(2))
+	inner2 := tuplepkg.NewTuple(big.NewInt(3), big.NewInt(4))
+	outer := tuplepkg.NewTuple(inner1.Copy(), inner2.Copy())
+
+	if err := state.Stack.PushTuple(outer.Copy()); err != nil {
+		t.Fatalf("failed to push outer tuple: %v", err)
+	}
+	if err := INDEX2(1, 0).Interpret(state); err != nil {
+		t.Fatalf("INDEX2 failed: %v", err)
+	}
+	if got := popInt(t, state); got != 3 {
+		t.Fatalf("INDEX2 returned %d, want 3", got)
+	}
+
+	deep := tuplepkg.NewTuple(big.NewInt(100), big.NewInt(200))
+	mid := tuplepkg.NewTuple(big.NewInt(50), deep.Copy())
+	outer3 := tuplepkg.NewTuple(mid.Copy(), big.NewInt(1))
+
+	if err := state.Stack.PushTuple(outer3.Copy()); err != nil {
+		t.Fatalf("failed to push nested tuple: %v", err)
+	}
+	if err := INDEX3(0, 1, 0).Interpret(state); err != nil {
+		t.Fatalf("INDEX3 failed: %v", err)
+	}
+	if got := popInt(t, state); got != 100 {
+		t.Fatalf("INDEX3 returned %d, want 100", got)
+	}
+}

--- a/tvm/op/tuple/pushnull.go
+++ b/tvm/op/tuple/pushnull.go
@@ -1,0 +1,20 @@
+package tuple
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return PUSHNULL() })
+}
+
+func PUSHNULL() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Name:   "PUSHNULL",
+		Prefix: []byte{0x6d},
+		Action: func(state *vm.State) error {
+			return state.Stack.PushAny(nil)
+		},
+	}
+}

--- a/tvm/op/tuple/qtlen.go
+++ b/tvm/op/tuple/qtlen.go
@@ -1,0 +1,30 @@
+package tuple
+
+import (
+	"math/big"
+
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	tuplepkg "github.com/xssnick/tonutils-go/tvm/tuple"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return QTLEN() })
+}
+
+func QTLEN() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Name:   "QTLEN",
+		Prefix: []byte{0x6f, 0x89},
+		Action: func(state *vm.State) error {
+			val, err := state.Stack.PopAny()
+			if err != nil {
+				return err
+			}
+			if tup, ok := val.(tuplepkg.Tuple); ok {
+				return state.Stack.PushInt(big.NewInt(int64(tup.Len())))
+			}
+			return state.Stack.PushInt(big.NewInt(-1))
+		},
+	}
+}

--- a/tvm/op/tuple/setindex.go
+++ b/tvm/op/tuple/setindex.go
@@ -1,0 +1,55 @@
+package tuple
+
+import (
+	"fmt"
+
+	"github.com/xssnick/tonutils-go/tvm/cell"
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+	"github.com/xssnick/tonutils-go/tvm/vmerr"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return SETINDEX(0) })
+}
+
+func SETINDEX(n uint8) *helpers.AdvancedOP {
+	return &helpers.AdvancedOP{
+		Prefix: cell.BeginCell().MustStoreUInt(0x6f5, 12).EndCell(),
+		NameSerializer: func() string {
+			return fmt.Sprintf("%d SETINDEX", n)
+		},
+		SerializeSuffix: func() *cell.Builder {
+			return cell.BeginCell().MustStoreUInt(uint64(n), 4)
+		},
+		DeserializeSuffix: func(code *cell.Slice) error {
+			val, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			n = uint8(val)
+			return nil
+		},
+		Action: func(state *vm.State) error {
+			return execSetIndex(state, int(n))
+		},
+	}
+}
+
+func execSetIndex(state *vm.State, idx int) error {
+	val, err := state.Stack.PopAny()
+	if err != nil {
+		return err
+	}
+	tup, err := state.Stack.PopTupleRange(255)
+	if err != nil {
+		return err
+	}
+	if idx >= tup.Len() || idx < 0 {
+		return vmerr.Error(vmerr.CodeRangeCheck, "tuple index out of range")
+	}
+	if err := (&tup).Set(idx, val); err != nil {
+		return err
+	}
+	return state.Stack.PushTuple(tup)
+}

--- a/tvm/op/tuple/setindexq.go
+++ b/tvm/op/tuple/setindexq.go
@@ -1,0 +1,80 @@
+package tuple
+
+import (
+	"fmt"
+
+	"github.com/xssnick/tonutils-go/tvm/cell"
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	tuplepkg "github.com/xssnick/tonutils-go/tvm/tuple"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+	"github.com/xssnick/tonutils-go/tvm/vmerr"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return SETINDEXQ(0) })
+}
+
+func SETINDEXQ(n uint8) *helpers.AdvancedOP {
+	return &helpers.AdvancedOP{
+		Prefix: cell.BeginCell().MustStoreUInt(0x6f7, 12).EndCell(),
+		NameSerializer: func() string {
+			return fmt.Sprintf("%d SETINDEXQ", n)
+		},
+		SerializeSuffix: func() *cell.Builder {
+			return cell.BeginCell().MustStoreUInt(uint64(n), 4)
+		},
+		DeserializeSuffix: func(code *cell.Slice) error {
+			val, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			n = uint8(val)
+			return nil
+		},
+		Action: func(state *vm.State) error {
+			return execSetIndexQuiet(state, int(n))
+		},
+	}
+}
+
+func execSetIndexQuiet(state *vm.State, idx int) error {
+	val, err := state.Stack.PopAny()
+	if err != nil {
+		return err
+	}
+	tup, err := state.Stack.PopMaybeTupleRange(255)
+	if err != nil {
+		return err
+	}
+	if idx < 0 || idx >= 255 {
+		return vmerr.Error(vmerr.CodeRangeCheck, "tuple index out of range")
+	}
+
+	length := 0
+	if tup != nil {
+		length = tup.Len()
+	}
+	if tup == nil {
+		if val == nil {
+			return state.Stack.PushAny(nil)
+		}
+		newTup := tuplepkg.NewTupleSized(idx + 1)
+		if err := (&newTup).Set(idx, val); err != nil {
+			return err
+		}
+		return state.Stack.PushTuple(newTup)
+	}
+
+	if idx >= length {
+		if val == nil {
+			return state.Stack.PushTuple(*tup)
+		}
+		tup.Resize(idx + 1)
+	}
+
+	if err := tup.Set(idx, val); err != nil {
+		return err
+	}
+
+	return state.Stack.PushTuple(*tup)
+}

--- a/tvm/op/tuple/setindexvar.go
+++ b/tvm/op/tuple/setindexvar.go
@@ -1,0 +1,24 @@
+package tuple
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return SETINDEXVAR() })
+}
+
+func SETINDEXVAR() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Name:   "SETINDEXVAR",
+		Prefix: []byte{0x6f, 0x85},
+		Action: func(state *vm.State) error {
+			idx, err := state.Stack.PopIntRange(0, 254)
+			if err != nil {
+				return err
+			}
+			return execSetIndex(state, int(idx.Int64()))
+		},
+	}
+}

--- a/tvm/op/tuple/setindexvarq.go
+++ b/tvm/op/tuple/setindexvarq.go
@@ -1,0 +1,24 @@
+package tuple
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return SETINDEXVARQ() })
+}
+
+func SETINDEXVARQ() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Name:   "SETINDEXVARQ",
+		Prefix: []byte{0x6f, 0x87},
+		Action: func(state *vm.State) error {
+			idx, err := state.Stack.PopIntRange(0, 254)
+			if err != nil {
+				return err
+			}
+			return execSetIndexQuiet(state, int(idx.Int64()))
+		},
+	}
+}

--- a/tvm/op/tuple/tlen.go
+++ b/tvm/op/tuple/tlen.go
@@ -1,0 +1,26 @@
+package tuple
+
+import (
+	"math/big"
+
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return TLEN() })
+}
+
+func TLEN() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Name:   "TLEN",
+		Prefix: []byte{0x6f, 0x88},
+		Action: func(state *vm.State) error {
+			tup, err := state.Stack.PopTupleRange(255)
+			if err != nil {
+				return err
+			}
+			return state.Stack.PushInt(big.NewInt(int64(tup.Len())))
+		},
+	}
+}

--- a/tvm/op/tuple/tpop.go
+++ b/tvm/op/tuple/tpop.go
@@ -1,0 +1,31 @@
+package tuple
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return TPOP() })
+}
+
+func TPOP() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Name:   "TPOP",
+		Prefix: []byte{0x6f, 0x8d},
+		Action: func(state *vm.State) error {
+			tup, err := state.Stack.PopTupleRange(255, 1)
+			if err != nil {
+				return err
+			}
+			val, err := tup.PopLast()
+			if err != nil {
+				return err
+			}
+			if err = state.Stack.PushTuple(tup); err != nil {
+				return err
+			}
+			return state.Stack.PushAny(val)
+		},
+	}
+}

--- a/tvm/op/tuple/tpush.go
+++ b/tvm/op/tuple/tpush.go
@@ -1,0 +1,29 @@
+package tuple
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return TPUSH() })
+}
+
+func TPUSH() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Name:   "TPUSH",
+		Prefix: []byte{0x6f, 0x8c},
+		Action: func(state *vm.State) error {
+			val, err := state.Stack.PopAny()
+			if err != nil {
+				return err
+			}
+			tup, err := state.Stack.PopTupleRange(254)
+			if err != nil {
+				return err
+			}
+			tup.Append(val)
+			return state.Stack.PushTuple(tup)
+		},
+	}
+}

--- a/tvm/op/tuple/tuple.go
+++ b/tvm/op/tuple/tuple.go
@@ -1,0 +1,63 @@
+package tuple
+
+import (
+	"fmt"
+
+	"github.com/xssnick/tonutils-go/tvm/cell"
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	tuplepkg "github.com/xssnick/tonutils-go/tvm/tuple"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+	"github.com/xssnick/tonutils-go/tvm/vmerr"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return TUPLE(0) })
+}
+
+func TUPLE(n uint8) *helpers.AdvancedOP {
+	return &helpers.AdvancedOP{
+		Prefix: cell.BeginCell().MustStoreUInt(0x6f0, 12).EndCell(),
+		NameSerializer: func() string {
+			return fmt.Sprintf("%d TUPLE", n)
+		},
+		SerializeSuffix: func() *cell.Builder {
+			return cell.BeginCell().MustStoreUInt(uint64(n), 4)
+		},
+		DeserializeSuffix: func(code *cell.Slice) error {
+			val, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			n = uint8(val)
+			return nil
+		},
+		Action: func(state *vm.State) error {
+			return execMakeTuple(state, int(n))
+		},
+	}
+}
+
+func execMakeTuple(state *vm.State, count int) error {
+	if count < 0 {
+		return vmerr.Error(vmerr.CodeRangeCheck)
+	}
+	if state.Stack.Len() < count {
+		return vmerr.Error(vmerr.CodeStackUnderflow)
+	}
+
+	vals := make([]any, count)
+	for i := 0; i < count; i++ {
+		val, err := state.Stack.Get(count - 1 - i)
+		if err != nil {
+			return err
+		}
+		vals[i] = val
+	}
+
+	if err := state.Stack.Drop(count); err != nil {
+		return err
+	}
+
+	newTuple := tuplepkg.NewTuple(vals...)
+	return state.Stack.PushTuple(*newTuple)
+}

--- a/tvm/op/tuple/tuplevar.go
+++ b/tvm/op/tuple/tuplevar.go
@@ -1,0 +1,24 @@
+package tuple
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List, func() vm.OP { return TUPLEVAR() })
+}
+
+func TUPLEVAR() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Name:   "TUPLEVAR",
+		Prefix: []byte{0x6f, 0x80},
+		Action: func(state *vm.State) error {
+			count, err := state.Stack.PopIntRange(0, 255)
+			if err != nil {
+				return err
+			}
+			return execMakeTuple(state, int(count.Int64()))
+		},
+	}
+}

--- a/tvm/op/tuple/untuple.go
+++ b/tvm/op/tuple/untuple.go
@@ -1,0 +1,95 @@
+package tuple
+
+import (
+	"fmt"
+
+	"github.com/xssnick/tonutils-go/tvm/cell"
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List,
+		func() vm.OP { return UNTUPLE(0) },
+		func() vm.OP { return UNPACKFIRST(0) },
+	)
+}
+
+func UNTUPLE(n uint8) *helpers.AdvancedOP {
+	return &helpers.AdvancedOP{
+		Prefix: cell.BeginCell().MustStoreUInt(0x6f2, 12).EndCell(),
+		NameSerializer: func() string {
+			return fmt.Sprintf("%d UNTUPLE", n)
+		},
+		SerializeSuffix: func() *cell.Builder {
+			return cell.BeginCell().MustStoreUInt(uint64(n), 4)
+		},
+		DeserializeSuffix: func(code *cell.Slice) error {
+			val, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			n = uint8(val)
+			return nil
+		},
+		Action: func(state *vm.State) error {
+			return execUntuple(state, int(n), true)
+		},
+	}
+}
+
+func UNPACKFIRST(n uint8) *helpers.AdvancedOP {
+	return &helpers.AdvancedOP{
+		Prefix: cell.BeginCell().MustStoreUInt(0x6f3, 12).EndCell(),
+		NameSerializer: func() string {
+			return fmt.Sprintf("%d UNPACKFIRST", n)
+		},
+		SerializeSuffix: func() *cell.Builder {
+			return cell.BeginCell().MustStoreUInt(uint64(n), 4)
+		},
+		DeserializeSuffix: func(code *cell.Slice) error {
+			val, err := code.LoadUInt(4)
+			if err != nil {
+				return err
+			}
+			n = uint8(val)
+			return nil
+		},
+		Action: func(state *vm.State) error {
+			return execUntuple(state, int(n), false)
+		},
+	}
+}
+
+func execUntuple(state *vm.State, count int, exact bool) error {
+	max := 255
+	min := 0
+	if exact {
+		max = count
+		min = count
+	} else {
+		min = count
+	}
+
+	tup, err := state.Stack.PopTupleRange(max, min)
+	if err != nil {
+		return err
+	}
+
+	limit := count
+	if !exact && limit > tup.Len() {
+		limit = tup.Len()
+	}
+
+	for i := 0; i < limit; i++ {
+		val, err := tup.Index(i)
+		if err != nil {
+			return err
+		}
+		if err = state.Stack.PushAny(val); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/tvm/op/tuple/untuplevar.go
+++ b/tvm/op/tuple/untuplevar.go
@@ -1,0 +1,41 @@
+package tuple
+
+import (
+	"github.com/xssnick/tonutils-go/tvm/op/helpers"
+	"github.com/xssnick/tonutils-go/tvm/vm"
+)
+
+func init() {
+	vm.List = append(vm.List,
+		func() vm.OP { return UNTUPLEVAR() },
+		func() vm.OP { return UNPACKFIRSTVAR() },
+	)
+}
+
+func UNTUPLEVAR() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Name:   "UNTUPLEVAR",
+		Prefix: []byte{0x6f, 0x82},
+		Action: func(state *vm.State) error {
+			count, err := state.Stack.PopIntRange(0, 255)
+			if err != nil {
+				return err
+			}
+			return execUntuple(state, int(count.Int64()), true)
+		},
+	}
+}
+
+func UNPACKFIRSTVAR() *helpers.SimpleOP {
+	return &helpers.SimpleOP{
+		Name:   "UNPACKFIRSTVAR",
+		Prefix: []byte{0x6f, 0x83},
+		Action: func(state *vm.State) error {
+			count, err := state.Stack.PopIntRange(0, 255)
+			if err != nil {
+				return err
+			}
+			return execUntuple(state, int(count.Int64()), false)
+		},
+	}
+}

--- a/tvm/tuple/tuple.go
+++ b/tvm/tuple/tuple.go
@@ -10,6 +10,13 @@ func NewTuple(val ...any) *Tuple {
 	return &Tuple{val}
 }
 
+func NewTupleSized(size int) Tuple {
+	if size < 0 {
+		size = 0
+	}
+	return Tuple{val: make([]any, size)}
+}
+
 func (t *Tuple) Len() int {
 	return len(t.val)
 }
@@ -21,10 +28,53 @@ func (t *Tuple) Copy() Tuple {
 }
 
 func (t *Tuple) Index(i int) (any, error) {
-	if i >= len(t.val) {
+	if i < 0 || i >= len(t.val) {
 		return nil, vmerr.Error(vmerr.CodeRangeCheck)
 	}
 	return t.val[i], nil
+}
+
+func (t *Tuple) Set(i int, val any) error {
+	if i < 0 || i >= len(t.val) {
+		return vmerr.Error(vmerr.CodeRangeCheck)
+	}
+	t.val[i] = val
+	return nil
+}
+
+func (t *Tuple) Resize(size int) {
+	if size < 0 {
+		size = 0
+	}
+
+	if size <= len(t.val) {
+		for i := size; i < len(t.val); i++ {
+			t.val[i] = nil
+		}
+		t.val = t.val[:size]
+		return
+	}
+
+	if size <= cap(t.val) {
+		t.val = append(t.val, make([]any, size-len(t.val))...)
+		return
+	}
+
+	newVal := make([]any, size)
+	copy(newVal, t.val)
+	t.val = newVal
+}
+
+func (t *Tuple) PopLast() (any, error) {
+	if len(t.val) == 0 {
+		return nil, vmerr.Error(vmerr.CodeRangeCheck)
+	}
+
+	idx := len(t.val) - 1
+	val := t.val[idx]
+	t.val[idx] = nil
+	t.val = t.val[:idx]
+	return val, nil
 }
 
 func (t *Tuple) Append(val any) {

--- a/tvm/vm/stack.go
+++ b/tvm/vm/stack.go
@@ -275,6 +275,64 @@ func (s *Stack) PopSlice() (*cell.Slice, error) {
 	}
 }
 
+func (s *Stack) PopTuple() (tuple.Tuple, error) {
+	e, err := s.PopAny()
+	if err != nil {
+		return tuple.Tuple{}, err
+	}
+	if v, ok := e.(tuple.Tuple); ok {
+		return v, nil
+	}
+	return tuple.Tuple{}, vmerr.Error(vmerr.CodeTypeCheck, "not a tuple")
+}
+
+func (s *Stack) PopTupleRange(max int, min ...int) (tuple.Tuple, error) {
+	t, err := s.PopTuple()
+	if err != nil {
+		return tuple.Tuple{}, err
+	}
+
+	lower := 0
+	if len(min) > 0 {
+		lower = min[0]
+	}
+
+	if (max >= 0 && t.Len() > max) || t.Len() < lower {
+		return tuple.Tuple{}, vmerr.Error(vmerr.CodeTypeCheck, "not a tuple of valid size")
+	}
+
+	return t, nil
+}
+
+func (s *Stack) PopMaybeTupleRange(max int) (*tuple.Tuple, error) {
+	e, err := s.PopAny()
+	if err != nil {
+		return nil, err
+	}
+	if e == nil {
+		return nil, nil
+	}
+	v, ok := e.(tuple.Tuple)
+	if !ok {
+		return nil, vmerr.Error(vmerr.CodeTypeCheck, "not a tuple")
+	}
+	if max >= 0 && v.Len() > max {
+		return nil, vmerr.Error(vmerr.CodeTypeCheck, "not a tuple of valid size")
+	}
+	return &v, nil
+}
+
+func (s *Stack) PushTuple(t tuple.Tuple) error {
+	return s.PushAny(t)
+}
+
+func (s *Stack) PushMaybeTuple(t *tuple.Tuple) error {
+	if t == nil {
+		return s.PushAny(nil)
+	}
+	return s.PushAny(*t)
+}
+
 func (s *Stack) PopIntRange(min, max int64) (*big.Int, error) {
 	e, err := s.PopInt()
 	if err != nil {


### PR DESCRIPTION
## Summary
- split the tuple opcode implementations into dedicated files to match the layout used by other opcode packages
- keep shared helpers such as tuple construction, unpacking, and quiet setters available for the refactored ops

## Testing
- go test ./tvm/op/tuple

------
https://chatgpt.com/codex/tasks/task_e_68d00390b34883208481d9c785980a98