### PR TITLE
Fix 32-bit int overflow in broadcast FEC sender

### DIFF
--- a/adnl/overlay/broadcast-fec-send.go
+++ b/adnl/overlay/broadcast-fec-send.go
@@ -121,7 +121,7 @@ func NewBroadcastFECSender(key ed25519.PrivateKey, certificate any, payload []by
 	if len(payload) == 0 {
 		return nil, fmt.Errorf("payload is empty")
 	}
-	if len(payload) > math.MaxUint32 {
+	if uint64(len(payload)) > math.MaxUint32 {
 		return nil, fmt.Errorf("payload is too large")
 	}
 


### PR DESCRIPTION
len(payload) is compared against math.MaxUint32, which overflows int
on 32-bit platforms (GOARCH=arm, 386) and breaks the build. Compare as uint64.