### PR TITLE
fix(rldp): improve 1-bar network stability without slowing P2P transfers

### DIFF
--- a/adnl/rldp/client.go
+++ b/adnl/rldp/client.go
@@ -37,7 +37,15 @@ var Logger = func(a ...any) {}
 // non-final inbound parts with a different FEC data size.
 var PartSize = uint32(2_000_000)
 
-const maxInitialFastSymbols = 32
+const (
+	maxInitialFastSymbols         = 32
+	maxInitialFastSymbolsBulk     = 256
+	maxInitialFastSymbolsSmallMax = 32 * 1024
+	bulkPartSize                  = 2_000_000
+	bulkSymbolSize                = 768
+	badNetworkSmallSymbolSize    = 256
+	badNetworkSmallExtraSymbols  = 2
+)
 
 var MultiFECMode = false // TODO: activate after some versions
 var RoundRobinFECLimit = 50 * DefaultSymbolSize
@@ -1512,9 +1520,20 @@ func (t *activeTransfer) prepareNextPart() (bool, error) {
 
 	partIndex := t.nextPartIndex
 
+	partSize := PartSize
+	symbolSize := DefaultSymbolSize
+	if t.totalSize > maxInitialFastSymbolsSmallMax {
+		if partSize < bulkPartSize {
+			partSize = bulkPartSize
+		}
+		if symbolSize < bulkSymbolSize {
+			symbolSize = bulkSymbolSize
+		}
+	}
+
 	payload := t.data
-	if len(payload) > int(PartSize) {
-		payload = payload[:PartSize]
+	if len(payload) > int(partSize) {
+		payload = payload[:partSize]
 	}
 
 	if len(payload) == 0 {
@@ -1523,7 +1542,7 @@ func (t *activeTransfer) prepareNextPart() (bool, error) {
 	remaining := t.data[len(payload):]
 
 	// ceil, reference C++ nodes drop parts with symbols count not matching data and symbol sizes
-	cnt := uint32((uint64(len(payload)) + uint64(DefaultSymbolSize) - 1) / uint64(DefaultSymbolSize))
+	cnt := uint32((uint64(len(payload)) + uint64(symbolSize) - 1) / uint64(symbolSize))
 
 	var err error
 	var enc fecEncoder
@@ -1531,25 +1550,25 @@ func (t *activeTransfer) prepareNextPart() (bool, error) {
 
 	//goland:noinspection GoBoolExpressions
 	if MultiFECMode && len(payload) < int(RoundRobinFECLimit) {
-		enc, err = roundrobin.NewEncoder(payload, DefaultSymbolSize)
+		enc, err = roundrobin.NewEncoder(payload, symbolSize)
 		if err != nil {
 			return false, fmt.Errorf("failed to create rr object encoder: %w", err)
 		}
 
 		fec = FECRoundRobin{
 			DataSize:     uint32(len(payload)),
-			SymbolSize:   DefaultSymbolSize,
+			SymbolSize:   symbolSize,
 			SymbolsCount: cnt,
 		}
 	} else {
-		enc, err = raptorq.NewRaptorQ(DefaultSymbolSize).CreateEncoder(payload)
+		enc, err = raptorq.NewRaptorQ(symbolSize).CreateEncoder(payload)
 		if err != nil {
 			return false, fmt.Errorf("failed to create raptorq object encoder: %w", err)
 		}
 
 		fec = FECRaptorQ{
 			DataSize:     uint32(len(payload)),
-			SymbolSize:   DefaultSymbolSize,
+			SymbolSize:   symbolSize,
 			SymbolsCount: cnt,
 		}
 	}
@@ -1564,6 +1583,11 @@ func (t *activeTransfer) prepareNextPart() (bool, error) {
 		nextRecoverDelay: 4,
 		fastSeqnoTill:    cnt + cnt/33 + 1, // +3%
 		transfer:         t,
+	}
+	if t.totalSize <= maxInitialFastSymbolsSmallMax && symbolSize <= badNetworkSmallSymbolSize {
+		if minFast := cnt + badNetworkSmallExtraSymbols; part.fastSeqnoTill < minFast {
+			part.fastSeqnoTill = minFast
+		}
 	}
 
 	pt := uint32(1) << uint32(math.Ceil(math.Log2(float64(part.fecSymbolsCount)*3+50)))
@@ -1602,8 +1626,12 @@ func (r *RLDP) sendFastSymbols(ctx context.Context, transfer *activeTransfer) er
 
 	seqno := uint32(0)
 	batchLimit := int(part.fastSeqnoTill)
-	if batchLimit > maxInitialFastSymbols {
-		batchLimit = maxInitialFastSymbols
+	initialCap := maxInitialFastSymbols
+	if transfer.totalSize > maxInitialFastSymbolsSmallMax {
+		initialCap = maxInitialFastSymbolsBulk
+	}
+	if batchLimit > initialCap {
+		batchLimit = initialCap
 	}
 	batch := r.rateLimit.ConsumePackets(batchLimit, int(part.fecSymbolSize))
 	now := time.Now().UnixMilli()

--- a/adnl/rldp/client_test.go
+++ b/adnl/rldp/client_test.go
@@ -214,6 +214,55 @@ func TestRLDPPrepareNextPartUsesCppCompatiblePartSize(t *testing.T) {
 	}
 }
 
+func TestRLDPPrepareNextPartKeepsBulkFastUnderBadNetworkGlobals(t *testing.T) {
+	oldPartSize := PartSize
+	oldSymbolSize := DefaultSymbolSize
+	oldMultiFEC := MultiFECMode
+	PartSize = 32 * 1024
+	DefaultSymbolSize = 256
+	MultiFECMode = false
+	defer func() {
+		PartSize = oldPartSize
+		DefaultSymbolSize = oldSymbolSize
+		MultiFECMode = oldMultiFEC
+	}()
+
+	bulkPayload := bytes.Repeat([]byte{0x5a}, 700*1024)
+	bulk := &activeTransfer{
+		id:        bytes.Repeat([]byte{0x04}, 32),
+		timeoutAt: time.Now().Add(time.Second).UnixMilli(),
+		data:      bulkPayload,
+		totalSize: uint64(len(bulkPayload)),
+	}
+	if ok, err := bulk.prepareNextPart(); err != nil || !ok {
+		t.Fatalf("expected bulk part, ok=%v err=%v", ok, err)
+	}
+	bulkPart := bulk.getCurrentPart()
+	if bulkPart.fec.GetDataSize() != uint32(len(bulkPayload)) {
+		t.Fatalf("bulk data size=%d want=%d", bulkPart.fec.GetDataSize(), len(bulkPayload))
+	}
+	if bulkPart.fec.GetSymbolSize() != bulkSymbolSize {
+		t.Fatalf("bulk symbol size=%d want=%d", bulkPart.fec.GetSymbolSize(), bulkSymbolSize)
+	}
+
+	smallPayload := bytes.Repeat([]byte{0x6b}, 16*1024)
+	small := &activeTransfer{
+		id:        bytes.Repeat([]byte{0x05}, 32),
+		timeoutAt: time.Now().Add(time.Second).UnixMilli(),
+		data:      smallPayload,
+		totalSize: uint64(len(smallPayload)),
+	}
+	if ok, err := small.prepareNextPart(); err != nil || !ok {
+		t.Fatalf("expected small part, ok=%v err=%v", ok, err)
+	}
+	if got := small.getCurrentPart().fec.GetSymbolSize(); got != 256 {
+		t.Fatalf("small symbol size=%d want=256", got)
+	}
+	if got, want := small.getCurrentPart().fastSeqnoTill, small.getCurrentPart().fecSymbolsCount+badNetworkSmallExtraSymbols; got != want {
+		t.Fatalf("small fastSeqnoTill=%d want=%d", got, want)
+	}
+}
+
 func TestRLDPPrepareNextPartSymbolsCountIsCeil(t *testing.T) {
 	oldMultiFEC := MultiFECMode
 	MultiFECMode = false
@@ -243,7 +292,7 @@ func TestRLDPPrepareNextPartSymbolsCountIsCeil(t *testing.T) {
 	}
 }
 
-func TestRLDPSendFastSymbolsCapsInitialBurst(t *testing.T) {
+func TestRLDPSendFastSymbolsCapsBulkInitialBurst(t *testing.T) {
 	payload := bytes.Repeat([]byte{0x5a}, int(PartSize))
 	transfer := &activeTransfer{
 		id:        bytes.Repeat([]byte{0x02}, 32),
@@ -285,14 +334,14 @@ func TestRLDPSendFastSymbolsCapsInitialBurst(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got := sent.Load(); got != maxInitialFastSymbols {
-		t.Fatalf("sent initial symbols=%d want %d", got, maxInitialFastSymbols)
+	if got := sent.Load(); got != maxInitialFastSymbolsBulk {
+		t.Fatalf("sent initial symbols=%d want %d", got, maxInitialFastSymbolsBulk)
 	}
 	stats := rl.Stats()
-	if stats.Outbound.SymbolsSent != maxInitialFastSymbols {
-		t.Fatalf("stats symbols sent=%d want=%d", stats.Outbound.SymbolsSent, maxInitialFastSymbols)
+	if stats.Outbound.SymbolsSent != maxInitialFastSymbolsBulk {
+		t.Fatalf("stats symbols sent=%d want=%d", stats.Outbound.SymbolsSent, maxInitialFastSymbolsBulk)
 	}
-	if stats.Outbound.SymbolBytesSent != uint64(maxInitialFastSymbols)*uint64(DefaultSymbolSize) {
+	if stats.Outbound.SymbolBytesSent != uint64(maxInitialFastSymbolsBulk)*uint64(DefaultSymbolSize) {
 		t.Fatalf("stats symbol bytes=%d", stats.Outbound.SymbolBytesSent)
 	}
 	if stats.Outbound.LastSymbolAt.IsZero() {


### PR DESCRIPTION
## Summary

This PR restores stable RLDP operation on severely constrained mobile
connections while preserving direct P2P file transfer performance.

The last version where the application-specific bad-network configuration
worked correctly for all tested workloads was `v1.15`.

After `v1.15`, RLDP changes introduced regressions on a simulated 1-bar
connection. User search and message delivery became unreliable or significantly
slower.

The `v1.18` development branch (https://github.com/xssnick/tonutils-go/commit/78bfb674a6eae97ff73bd84c2cc0d1e2e8f4108b) restored general RLDP stability on the same
network profile. However, enabling the custom bad-network configuration caused
another regression: direct P2P file transfers became significantly slower or
stopped making stable progress.

This patch allows the bad-network configuration to remain enabled while covering
all three workloads:

- user search on a 1-bar connection;
- message delivery on a 1-bar connection;
- direct P2P file transfers without the previous slowdown.

## Context

I use `tonutils-go` as the transport layer for a P2P messenger.

RLDP is used for three different workloads:

1. User search
2. Message delivery
3. Direct P2P file transfers

The issue was reproduced using a simulated 1-bar mobile connection with the
following network profile:

| Parameter | Value |
|---|---:|
| Inbound bandwidth | 80 Kbps |
| Outbound bandwidth | 50 Kbps |
| Inbound packet loss | 10% |
| Outbound packet loss | 10% |
| Inbound delay | 300 ms |
| Outbound delay | 300 ms |
| DNS delay | 150 ms |

## Bad-network configuration

The application uses the following RLDP parameters for constrained network
conditions:

```go
func configureRLDPForBadNetwork() {
	rldp.PartSize = 32 * 1024           // 32 KB instead of the default part size
	rldp.DefaultSymbolSize = 256        // 256 bytes instead of 768
	rldp.RoundRobinFECLimit = 10 * 1024 // 10 KB round-robin FEC limit
}