### PR TITLE
Fixed gas prices config check on lazily loaded cells

### DIFF
--- a/tlb/config_prices.go
+++ b/tlb/config_prices.go
@@ -142,6 +142,13 @@ func (c *ConfigGasLimitsPrices) LoadFromCell(loader *cell.Slice) error {
 		return err
 	}
 
+	// Parsing runs on a copy so a failed record leaves the caller's slice untouched,
+	// but on success the loader must be advanced like every other TLB type, otherwise
+	// callers cannot tell whether the record was fully consumed.
+	if err = loader.SkipBits(loader.BitsLeft() - work.BitsLeft()); err != nil {
+		return err
+	}
+
 	*c = out
 	return nil
 }

--- a/tvm/transaction_config.go
+++ b/tvm/transaction_config.go
@@ -578,20 +578,15 @@ func transactionLoadGasPricesStrict(blockchainCfg tlb.BlockchainConfig, masterch
 		return nil, fmt.Errorf("failed to load gas prices config param %d: %w", paramID, err)
 	}
 
-	var prices tlb.ConfigGasLimitsPrices
-	if err = tlb.Parse(&prices, root); err != nil {
+	loader, err := root.BeginParse()
+	if err != nil {
 		return nil, fmt.Errorf("failed to parse gas prices config param %d: %w", paramID, err)
 	}
-	// ConfigGasLimitsPrices parses a copy of the slice, so exactness is checked
-	// against the serialized size of the parsed record.
-	expectedBits := uint(392) // 8-bit tag + 3x64 gas fields + 3x64 block/due limits
-	if prices.HasSeparateSpecialLimit {
-		expectedBits += 64
+	var prices tlb.ConfigGasLimitsPrices
+	if err = tlb.LoadFromCell(&prices, loader); err != nil {
+		return nil, fmt.Errorf("failed to parse gas prices config param %d: %w", paramID, err)
 	}
-	if prices.HasFlatPricing {
-		expectedBits += 136 // 8-bit tag + 2x64 flat fields
-	}
-	if root.BitsSize() != expectedBits || root.RefsNum() != 0 {
+	if loader.BitsLeft() != 0 || loader.RefsNum() != 0 {
 		return nil, fmt.Errorf("gas prices config param %d has unparsed data", paramID)
 	}
 	return &prices, nil

--- a/tvm/transaction_config_lazy_test.go
+++ b/tvm/transaction_config_lazy_test.go
@@ -1,0 +1,95 @@
+package tvm
+
+import (
+	"testing"
+
+	"github.com/xssnick/tonutils-go/tlb"
+	"github.com/xssnick/tonutils-go/tvm/cell"
+)
+
+// A node serving a config out of its storage hands over a lazily parsed root, so a
+// config param sitting below the materialized part is still a pruned placeholder when
+// the strict loaders inspect it. Everything that reads the declared size of such a cell
+// instead of parsing it sees the placeholder, not the record.
+func lazyReparse(t *testing.T, c *cell.Cell) *cell.Cell {
+	t.Helper()
+
+	roots, _, err := cell.FromBOCMultiRootReader(cell.NewBOCNoCopyReader(c.ToBOC()), cell.BOCParseOptions{Lazy: true})
+	if err != nil {
+		t.Fatalf("failed to reparse config root lazily: %v", err)
+	}
+	if len(roots) != 1 {
+		t.Fatalf("lazy reparse produced %d roots, want 1", len(roots))
+	}
+	return roots[0]
+}
+
+func TestTransactionLoadGasPricesStrictAcceptsLazyConfigRoot(t *testing.T) {
+	prices := tlb.ConfigGasLimitsPrices{
+		HasFlatPricing:          true,
+		FlatGasLimit:            1000,
+		FlatGasPrice:            1000000,
+		HasSeparateSpecialLimit: true,
+		GasPrice:                65536000,
+		GasLimit:                1000000,
+		SpecialGasLimit:         1000000,
+		GasCredit:               10000,
+		BlockGasLimit:           10000000,
+		FreezeDueLimit:          100000000,
+		DeleteDueLimit:          1000000000,
+	}
+
+	root := buildTransactionConfigRoot(t, map[uint32]*cell.Cell{
+		tlb.ConfigParamGasPricesBasechain: transactionFeesGasPricesCell(t, prices),
+	})
+
+	for _, tc := range []struct {
+		name string
+		root *cell.Cell
+	}{
+		{name: "materialized", root: root},
+		{name: "lazy", root: lazyReparse(t, root)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := transactionLoadGasPricesStrict(tlb.BlockchainConfig{Root: tc.root}, false)
+			if err != nil {
+				t.Fatalf("strict gas prices load failed: %v", err)
+			}
+			if *got != prices {
+				t.Fatalf("gas prices = %+v, want %+v", *got, prices)
+			}
+		})
+	}
+}
+
+func TestTransactionLoadGasPricesStrictRejectsTrailingData(t *testing.T) {
+	prices := tlb.ConfigGasLimitsPrices{
+		GasPrice:       65536000,
+		GasLimit:       1000000,
+		GasCredit:      10000,
+		BlockGasLimit:  10000000,
+		FreezeDueLimit: 100000000,
+		DeleteDueLimit: 1000000000,
+	}
+	priceCell := transactionFeesGasPricesCell(t, prices)
+
+	padded := cell.BeginCell().MustStoreBuilder(priceCell.ToBuilder()).MustStoreUInt(0, 1).EndCell()
+
+	root := buildTransactionConfigRoot(t, map[uint32]*cell.Cell{
+		tlb.ConfigParamGasPricesBasechain: padded,
+	})
+
+	for _, tc := range []struct {
+		name string
+		root *cell.Cell
+	}{
+		{name: "materialized", root: root},
+		{name: "lazy", root: lazyReparse(t, root)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := transactionLoadGasPricesStrict(tlb.BlockchainConfig{Root: tc.root}, false); err == nil {
+				t.Fatal("strict gas prices load accepted a param with trailing data")
+			}
+		})
+	}
+}


### PR DESCRIPTION
A node that serves a blockchain config out of its own storage parses it lazily, so config params below the materialized part are still pruned placeholders when the strict loaders look at them.

`transactionLoadGasPricesStrict` verifies "fully consumed" by comparing `root.BitsSize()` with the expected record size. `BitsSize()` returns the stored field without loading the cell, so on a lazy root it reports the placeholder, never the record — and a perfectly valid param 20/21 is rejected with `gas prices config param 21 has unparsed data`. The two sibling loaders (msg forward prices, size limits) are unaffected because they check `BitsLeft`/`RefsNum` after parsing.

The gas loader could not do that: `ConfigGasLimitsPrices.LoadFromCell` parses `loader.Copy()` and never advances the caller's slice, which is what the comment above the size check refers to.

So `LoadFromCell` now advances the loader on success (parsing still runs on a copy, so a malformed record leaves the caller's slice untouched), and the strict loader checks `BitsLeft`/`RefsNum` like its siblings. Existing callers in `tvm/op/funcs` already pass `sl.Copy()`, so nothing relies on the old non-consuming behaviour.

Found while running a Go node against a private TON network: every external message was refused by the liteserver, because the config epoch is built from a root prewarmed only a few levels deep.

`TestTransactionLoadGasPricesStrictAcceptsLazyConfigRoot` reproduces it — the same config passes materialized and fails lazily on the current code:

```
--- FAIL: TestTransactionLoadGasPricesStrictAcceptsLazyConfigRoot/lazy
    strict gas prices load failed: gas prices config param 21 has unparsed data
```

`TestTransactionLoadGasPricesStrictRejectsTrailingData` pins the check that is being replaced, so a param with a trailing bit is still rejected in both modes. `go test ./tlb/... ./tvm/... ./tvm/cell/...` passes.