### PR TITLE
docs(wallet): document SimpleMessage's hardcoded Bounce=true footgun

### DIFF
--- a/ton/wallet/wallet.go
+++ b/ton/wallet/wallet.go
@@ -809,6 +809,13 @@ func (w *Wallet) DeployContract(ctx context.Context, amount tlb.Coins, msgBody, 
 	return addr, nil
 }
 
+// SimpleMessage - always sets Bounce to true, regardless of the destination
+// address's own bounceable flag. If the destination account may be
+// uninitialized (e.g. it has never received funds, or is a marker address
+// with no deployed code), a bounceable message that can't be processed will
+// have its funds bounced back to the sender instead of credited - use
+// TransferNoBounce, SimpleMessageAutoBounce, or an explicit
+// InternalMessage.Bounce = false in that case.
 func SimpleMessage(to *address.Address, amount tlb.Coins, payload *cell.Cell) *Message {
 	return &Message{
 		Mode: PayGasSeparately + IgnoreErrors,


### PR DESCRIPTION
## What

Adds a doc comment to `wallet.SimpleMessage` explaining that it always sets `Bounce: true` regardless of the destination address, with no way to opt out through this API.

## Why

`SimpleMessage` hardcodes `InternalMessage.Bounce = true`. If the destination account is uninitialized (no deployed code — e.g. it has never received funds before, or is a marker/registration address), TON's standard behavior for a bounceable message that can't be processed (compute phase skipped, `cskip_no_state`) is to bounce the funds back to the sender instead of crediting the destination. The transaction appears to "go through" (it's accepted and produces an outbound message), but the intended action at the destination silently does not happen.

This is easy to miss because:
- `SimpleMessage` has no doc comment warning about this.
- The library already has alternatives for this exact situation (`SimpleMessageAutoBounce`, `TransferNoBounce`, or setting `InternalMessage.Bounce = false` explicitly), but nothing in `SimpleMessage` itself points a caller toward them.

I ran into this concretely while debugging a TON Storage provider-registration transaction: the registration message was sent via `SimpleMessage` to a target that turned out to be uninitialized, so it silently bounced back instead of registering, with no error surfaced at the call site.

## Change

Doc-comment only, no behavior change:

```go
// SimpleMessage - always sets Bounce to true, regardless of the destination
// address's own bounceable flag. If the destination account may be
// uninitialized (e.g. it has never received funds, or is a marker address
// with no deployed code), a bounceable message that can't be processed will
// have its funds bounced back to the sender instead of credited - use
// TransferNoBounce, SimpleMessageAutoBounce, or an explicit
// InternalMessage.Bounce = false in that case.
func SimpleMessage(to *address.Address, amount tlb.Coins, payload *cell.Cell) *Message {
```

## Testing

- `go build ./ton/wallet/...` succeeds.
- `git diff` confirms the change is limited to this single doc comment.