### PR TITLE
fix(address): prevent panic in UnmarshalJSON on short EXT/VAR data

### DIFF
--- a/address/addr.go
+++ b/address/addr.go
@@ -168,6 +168,10 @@ func (a *Address) UnmarshalJSON(data []byte) error {
 			return err
 		}
 
+		if len(b) < 5 {
+			return fmt.Errorf("invalid ext address")
+		}
+
 		addr = NewAddressExt(
 			b[0],
 			uint(binary.BigEndian.Uint32(b[1:5])),
@@ -180,6 +184,10 @@ func (a *Address) UnmarshalJSON(data []byte) error {
 		b, err := hex.DecodeString(strData)
 		if err != nil {
 			return err
+		}
+
+		if len(b) < 9 {
+			return fmt.Errorf("invalid var address")
 		}
 
 		addr = NewAddressVar(

--- a/address/addr_test.go
+++ b/address/addr_test.go
@@ -731,3 +731,41 @@ func TestAddress_Eq(t *testing.T) {
 		t.Fatal("not eq")
 	}
 }
+
+func TestAddress_UnmarshalJSON_MalformedDoesNotPanic(t *testing.T) {
+	// Regression: EXT:/VAR: branches decoded hex then indexed b[1:5]/b[5:9]
+	// without checking the decoded length, panicking on short-but-valid hex.
+	cases := []string{
+		`"EXT:aabbcc"`,           // 3 bytes, needs >=5
+		`"EXT:"`,                 // 0 bytes
+		`"VAR:aabbccddeeff"`,     // 6 bytes, needs >=9
+		`"VAR:aabb"`,             // 2 bytes
+	}
+	for _, c := range cases {
+		var a Address
+		// Must return an error, must not panic.
+		if err := a.UnmarshalJSON([]byte(c)); err == nil {
+			t.Errorf("expected error for malformed input %s, got nil", c)
+		}
+	}
+}
+
+func TestAddress_UnmarshalJSON_ValidStillWorks(t *testing.T) {
+	// A well-formed std address must still round-trip through JSON.
+	data := make([]byte, 32)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	orig := NewAddress(0, 0, data)
+	js, err := orig.MarshalJSON()
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got Address
+	if err := got.UnmarshalJSON(js); err != nil {
+		t.Fatalf("unmarshal of valid address failed: %v", err)
+	}
+	if !got.Equals(orig) {
+		t.Errorf("round-trip mismatch: got %s want %s", got.String(), orig.String())
+	}
+}


### PR DESCRIPTION
## Problem

`Address.UnmarshalJSON` guards the `EXT:` / `VAR:` branches on the length of the **full string** (`len(strData) >= 9` / `>= 13`), but then indexes the **decoded** bytes without checking how many bytes actually came back:

```go
} else if len(strData) >= 9 && strData[:4] == "EXT:" {
    strData = strData[4:]
    b, err := hex.DecodeString(strData)
    if err != nil { return err }
    addr = NewAddressExt(b[0], uint(binary.BigEndian.Uint32(b[1:5])), b[5:]) // b[1:5] needs >=5 bytes
```

A malformed-but-hex-valid payload slips past the string-length guard and panics. For example `"EXT:aabbcc"` (length 10 ≥ 9) decodes to **3 bytes**, then `b[1:5]` panics:

```
panic: runtime error: slice bounds out of range [:5] with capacity 3
    .../address/addr.go:173 Address.UnmarshalJSON
```

The `VAR:` branch has the same flaw (`b[1:5]` / `b[5:9]` need ≥9 decoded bytes, but the guard only ensures the string is ≥13 chars). Since `UnmarshalJSON` runs on untrusted input via `json.Unmarshal`, a crafted JSON string crashes the caller.

## Fix

Check the decoded length before indexing, and return an error instead of panicking:

```go
if len(b) < 5 { return fmt.Errorf("invalid ext address") }   // EXT
if len(b) < 9 { return fmt.Errorf("invalid var address") }   // VAR
```

## Tests

Added to `addr_test.go`:
- `TestAddress_UnmarshalJSON_MalformedDoesNotPanic` — `"EXT:aabbcc"`, `"EXT:"`, `"VAR:aabbccddeeff"`, `"VAR:aabb"` all return an error, no panic.
- `TestAddress_UnmarshalJSON_ValidStillWorks` — a valid std address still round-trips through `MarshalJSON`/`UnmarshalJSON`.

## Verification

Built and tested locally with Go 1.23:

```
go test ./address/    # ok — full package, no regressions
go vet ./address/     # clean
```

Confirmed the failing case panics before the change and passes after.
